### PR TITLE
Configure Zowe profile and Build order

### DIFF
--- a/.setup/build/.zosattributes
+++ b/.setup/build/.zosattributes
@@ -1,7 +1,0 @@
-# pattern local-encoding remote-encoding
-# Don't upload the node_modules directory
-.* -
-*.jpg binary binary
-
-*.profile UTF-8 EBCDIC
-*.yaml UTF-8 UTF-8

--- a/.setup/build/languages/Cobol.yaml
+++ b/.setup/build/languages/Cobol.yaml
@@ -24,6 +24,7 @@ tasks:
       # conditional variable builds compile parameters i.e CICS,SQL
       - name: LOAD_LLQ
         value: LOAD
+      
       - name: compileParms
         value: LIB
         append:

--- a/.setup/config.yaml
+++ b/.setup/config.yaml
@@ -10,6 +10,10 @@ repositories:
     url: https://github.com/IBM/dbb.git
     target_dir: dbb
 
+zowe: 
+  rse-profile: onDemand.rse
+  base-profile: onDemand.base
+
 # zBuilder framework configuration
 zbuilder:
   # Local source directory (relative to .setup)

--- a/.setup/run_pipeline.sh
+++ b/.setup/run_pipeline.sh
@@ -47,6 +47,7 @@ fi
 
 PIPELINE_BASE_WORKSPACE=$PIPELINE_WORKSPACE
 
+RSE_PROFILE=$(get_section_value 'zowe' 'rse-profile')
 PIPELINE_SCRIPT_SOURCE="$SCRIPT_DIR/$(get_section_value 'pipeline_script' 'source')"
 PIPELINE_SCRIPT_TARGET=$(expand_vars "$(get_section_value 'pipeline_script' 'target')")
 PIPELINE_SCRIPT_WORKSPACE=$(expand_vars "$(get_section_value 'pipeline_script' 'workspace')")
@@ -78,18 +79,18 @@ fi
 # Ensure parent directory exists on USS
 SCRIPT_PARENT_DIR=$(dirname "$PIPELINE_SCRIPT_TARGET")
 print_info "Ensuring parent directory exists: $SCRIPT_PARENT_DIR"
-zowe rse-api-for-zowe-cli create uss-directory "$SCRIPT_PARENT_DIR" &> /dev/null || true
+zowe rse-api-for-zowe-cli create uss-directory "$SCRIPT_PARENT_DIR" --rse-profile "$RSE_PROFILE" &> /dev/null || true
 
 # Delete existing file if it exists
 print_info "Removing existing pipeline script if present..."
-zowe rse-api-for-zowe-cli delete uss-file "$PIPELINE_SCRIPT_TARGET" &> /dev/null || true
+zowe rse-api-for-zowe-cli delete uss-file "$PIPELINE_SCRIPT_TARGET" --rse-profile "$RSE_PROFILE" &> /dev/null || true
 
 # Upload the script directly (no sed modifications needed)
 print_info "Uploading pipeline simulation build script to USS..."
-if zowe rse-api-for-zowe-cli upload file-to-uss "$PIPELINE_SCRIPT_SOURCE" "$PIPELINE_SCRIPT_TARGET" --encoding IBM-1047; then
+if zowe rse-api-for-zowe-cli upload file-to-uss "$PIPELINE_SCRIPT_SOURCE" "$PIPELINE_SCRIPT_TARGET" --rse-profile "$RSE_PROFILE" --encoding IBM-1047; then
     # Make script executable
     print_info "Making script executable..."
-    zowe rse-api-for-zowe-cli issue unix "chmod +x $(basename $PIPELINE_SCRIPT_TARGET)" --cwd "$SCRIPT_PARENT_DIR"
+    zowe rse-api-for-zowe-cli issue unix "chmod +x $(basename $PIPELINE_SCRIPT_TARGET)" --cwd "$SCRIPT_PARENT_DIR" --rse-profile "$RSE_PROFILE"
     
     print_success "Pipeline simulation build script uploaded successfully"
 else
@@ -98,7 +99,7 @@ else
 fi
 
 print_info "Uploading pipeline simulation deploy scripts to USS..."
-if zowe rse-api-for-zowe-cli upload dir-to-uss "$(dirname "$PIPELINE_SCRIPT_SOURCE")/deploy" "$(dirname $PIPELINE_SCRIPT_TARGET)/deploy" --encoding UTF-8; then
+if zowe rse-api-for-zowe-cli upload dir-to-uss "$(dirname "$PIPELINE_SCRIPT_SOURCE")/deploy" "$(dirname $PIPELINE_SCRIPT_TARGET)/deploy" --rse-profile "$RSE_PROFILE" --encoding UTF-8; then
     print_success "Pipeline simulation deploy scripts uploaded successfully"
 else
     print_error "Failed to upload pipeline simulation script"
@@ -122,6 +123,6 @@ export PIPELINE_WORKSPACE='$PIPELINE_WORKSPACE' && \
 export JAVA_HOME='$JAVA_HOME' && \
 $PIPELINE_SCRIPT_TARGET $GIT_REPO $GIT_BRANCH"
 
-zowe rse-api-for-zowe-cli issue unix-shell "$EXEC_CMD" --cwd "$SCRIPT_PARENT_DIR"
+zowe rse-api-for-zowe-cli issue unix-shell "$EXEC_CMD" --cwd "$SCRIPT_PARENT_DIR" --rse-profile "$RSE_PROFILE"
 
 # Made with Bob

--- a/.setup/setup.sh
+++ b/.setup/setup.sh
@@ -42,10 +42,10 @@ upload_directory_recursive() {
         local target_parent=$(dirname "$target_path")
         
         # Create parent directory on USS if it doesn't exist (ignore errors if already exists)
-        zowe rse-api-for-zowe-cli create uss-directory "$target_parent" &> /dev/null
+        zowe rse-api-for-zowe-cli create uss-directory "$target_parent" --rse-profile "$RSE_PROFILE" &> /dev/null
         
         # Upload file
-        if zowe rse-api-for-zowe-cli upload file-to-uss "$file" "$target_path" &> /dev/null; then
+        if zowe rse-api-for-zowe-cli upload file-to-uss "$file" "$target_path" --rse-profile "$RSE_PROFILE" &> /dev/null; then
             ((file_count++))
             if [ $((file_count % 10)) -eq 0 ]; then
                 print_info "Uploaded $file_count files..."
@@ -81,6 +81,7 @@ load_config() {
         PIPELINE_WORKSPACE=$(expand_vars "$(get_section_value 'global' 'sandbox')")
     fi
     DBB_REPO_URL=$(get_config_value 'url')
+    RSE_PROFILE=$(get_section_value 'zowe' 'rse-profile')
     ZBUILDER_SOURCE="$SCRIPT_DIR/$(get_section_value 'zbuilder' 'source_dir')"
     ZBUILDER_TARGET=$(expand_vars "$(get_section_value 'zbuilder' 'target_dir')")
     PIPELINE_SCRIPT_SOURCE="$SCRIPT_DIR/$(get_section_value 'pipeline_script' 'source')"
@@ -101,13 +102,13 @@ stage1_initialize_workspace() {
     # Check if directory exists on remote system
     print_info "Checking if workspace directory exists on remote system..."
     
-    if zowe rse-api-for-zowe-cli list uss "$PIPELINE_WORKSPACE" &> /dev/null; then
+    if zowe rse-api-for-zowe-cli list uss "$PIPELINE_WORKSPACE" --rse-profile "$RSE_PROFILE" &> /dev/null; then
         print_warning "Workspace directory already exists: $PIPELINE_WORKSPACE"
         read -p "Do you want to delete and recreate it? (y/N): " -n 1 -r
         echo
         if [[ $REPLY =~ ^[Yy]$ ]]; then
             print_info "Deleting existing workspace directory..."
-            zowe rse-api-for-zowe-cli delete uss "$PIPELINE_WORKSPACE"
+            zowe rse-api-for-zowe-cli delete uss "$PIPELINE_WORKSPACE" --rse-profile "$RSE_PROFILE"
             print_success "Existing workspace deleted"
         else
             print_info "Keeping existing workspace directory"
@@ -117,7 +118,7 @@ stage1_initialize_workspace() {
     
     # Create workspace directory
     print_info "Creating workspace directory: $PIPELINE_WORKSPACE"
-    zowe rse-api-for-zowe-cli create uss-directory "$PIPELINE_WORKSPACE"
+    zowe rse-api-for-zowe-cli create uss-directory "$PIPELINE_WORKSPACE" --rse-profile "$RSE_PROFILE"
     
     rm -rf $HOME/.dbb
     print_success "DBB metadata cache purged"
@@ -137,7 +138,7 @@ stage2_clone_accelerators() {
     
     # Check if git is available on the remote system
     print_info "Checking git availability on remote system..."
-    if ! zowe rse-api-for-zowe-cli issue unix "which git" --cwd "$PIPELINE_WORKSPACE" &> /dev/null; then
+    if ! zowe rse-api-for-zowe-cli issue unix "which git" --cwd "$PIPELINE_WORKSPACE" --rse-profile "$RSE_PROFILE" &> /dev/null; then
         print_error "Git is not available on the remote z/OS system"
         print_info "Please ensure git is installed and in the PATH on z/OS USS"
         exit 1
@@ -146,13 +147,13 @@ stage2_clone_accelerators() {
     
     # Check if dbb directory already exists
     print_info "Checking if dbb directory already exists..."
-    if zowe rse-api-for-zowe-cli list uss "$PIPELINE_WORKSPACE/dbb" &> /dev/null; then
+    if zowe rse-api-for-zowe-cli list uss "$PIPELINE_WORKSPACE/dbb" --rse-profile "$RSE_PROFILE" &> /dev/null; then
         print_warning "DBB directory already exists: $PIPELINE_WORKSPACE/dbb"
         read -p "Do you want to delete and re-clone it? (y/N): " -n 1 -r
         echo
         if [[ $REPLY =~ ^[Yy]$ ]]; then
             print_info "Removing existing dbb directory..."
-            zowe rse-api-for-zowe-cli issue unix "rm -rf dbb" --cwd "$PIPELINE_WORKSPACE"
+            zowe rse-api-for-zowe-cli issue unix "rm -rf dbb" --cwd "$PIPELINE_WORKSPACE" --rse-profile "$RSE_PROFILE"
             print_success "Existing dbb directory removed"
         else
             print_info "Keeping existing dbb directory"
@@ -162,7 +163,7 @@ stage2_clone_accelerators() {
     
     # Clone repository on remote system
     print_info "Cloning repository on remote z/OS system (this may take a few minutes)..."
-    if zowe rse-api-for-zowe-cli issue unix "git clone $DBB_REPO_URL" --cwd "$PIPELINE_WORKSPACE"; then
+    if zowe rse-api-for-zowe-cli issue unix "git clone $DBB_REPO_URL" --cwd "$PIPELINE_WORKSPACE" --rse-profile "$RSE_PROFILE"; then
         print_success "DBB repository cloned successfully on remote system"
     else
         print_error "Failed to clone DBB repository on remote system"
@@ -175,7 +176,7 @@ stage2_clone_accelerators() {
     
     # Verify the clone
     print_info "Verifying cloned repository..."
-    if zowe rse-api-for-zowe-cli list uss "$PIPELINE_WORKSPACE/dbb" &> /dev/null; then
+    if zowe rse-api-for-zowe-cli list uss "$PIPELINE_WORKSPACE/dbb" --rse-profile "$RSE_PROFILE" &> /dev/null; then
         print_success "Repository verification successful"
     else
         print_error "Repository verification failed"
@@ -212,13 +213,13 @@ stage3_upload_framework() {
     
     # Check if target directory already exists
     print_info "Checking if zBuilder directory already exists..."
-    if zowe rse-api-for-zowe-cli list uss "$ZBUILDER_TARGET" &> /dev/null; then
+    if zowe rse-api-for-zowe-cli list uss "$ZBUILDER_TARGET" --rse-profile "$RSE_PROFILE" &> /dev/null; then
         print_warning "zBuilder directory already exists: $ZBUILDER_TARGET"
         read -p "Do you want to delete and re-upload it? (y/N): " -n 1 -r
         echo
         if [[ $REPLY =~ ^[Yy]$ ]]; then
             print_info "Removing existing zBuilder directory..."
-            zowe rse-api-for-zowe-cli issue unix "rm -rf $(basename $ZBUILDER_TARGET)" --cwd "$(dirname $ZBUILDER_TARGET)"
+            zowe rse-api-for-zowe-cli issue unix "rm -rf $(basename $ZBUILDER_TARGET)" --cwd "$(dirname $ZBUILDER_TARGET)" --rse-profile "$RSE_PROFILE"
             print_success "Existing zBuilder directory removed"
         else
             print_info "Keeping existing zBuilder directory, skipping upload"
@@ -229,15 +230,15 @@ stage3_upload_framework() {
     # Create parent directory if needed
     PARENT_DIR=$(dirname "$ZBUILDER_TARGET")
     print_info "Ensuring parent directory exists: $PARENT_DIR"
-    if ! zowe rse-api-for-zowe-cli list uss "$PARENT_DIR" &> /dev/null; then
-        zowe rse-api-for-zowe-cli create uss-directory "$PARENT_DIR"
+    if ! zowe rse-api-for-zowe-cli list uss "$PARENT_DIR" --rse-profile "$RSE_PROFILE" &> /dev/null; then
+        zowe rse-api-for-zowe-cli create uss-directory "$PARENT_DIR" --rse-profile "$RSE_PROFILE"
     else
         print_info "Parent directory already exists: $PARENT_DIR"
     fi
     
     # Create target directory
     print_info "Creating target directory: $ZBUILDER_TARGET"
-    if ! zowe rse-api-for-zowe-cli create uss-directory "$ZBUILDER_TARGET" &> /dev/null; then
+    if ! zowe rse-api-for-zowe-cli create uss-directory "$ZBUILDER_TARGET" --rse-profile "$RSE_PROFILE" &> /dev/null; then
         print_warning "Target directory may already exist or creation failed"
     fi
     
@@ -259,13 +260,13 @@ stage3_upload_framework() {
 #########################################################
 stage4_build_and_install() {
     print_stage "STAGE 4: Build and install Bank of Z"
-    if ! zowe rse-api-for-zowe-cli issue unix-shell "git clone https://github.com/IBM/Bank-of-Z.git -b $(git rev-parse --abbrev-ref HEAD)" --cwd "$PIPELINE_WORKSPACE" &> /dev/null; then
+    if ! zowe rse-api-for-zowe-cli issue unix-shell "git clone https://github.com/IBM/Bank-of-Z.git -b $(git rev-parse --abbrev-ref HEAD)" --cwd "$PIPELINE_WORKSPACE" --rse-profile "$RSE_PROFILE" &> /dev/null; then
         print_error "Failed to clone https://github.com/IBM/Bank-of-Z.git on the target!!"
         exit 1
     fi
     print_success "Clone of https://github.com/IBM/Bank-of-Z.git branch $(git rev-parse --abbrev-ref HEAD) runs successfully"
     set -o pipefail
-    if ! zowe rse-api-for-zowe-cli issue unix-shell "$PIPELINE_WORKSPACE/Bank-of-Z/.setup/build.sh" --cwd "$PIPELINE_WORKSPACE/Bank-of-Z" 2>&1 | tee /tmp/build.log; then
+    if ! zowe rse-api-for-zowe-cli issue unix-shell "$PIPELINE_WORKSPACE/Bank-of-Z/.setup/build.sh" --cwd "$PIPELINE_WORKSPACE/Bank-of-Z" --rse-profile "$RSE_PROFILE" 2>&1 | tee /tmp/build.log; then
         print_error "Failed install Bank of Z on the target!!"
         exit 1
     fi

--- a/dbb-app.yaml
+++ b/dbb-app.yaml
@@ -66,6 +66,12 @@ application:
         - name: doLinkEdit
           value: true
 
+        # List of statically called submodules that need to be proccessed first
+        - name: fileBuildRank
+          value: 1
+          forFiles: "**/src/base/cics/cobol/EMLVALID.cbl"
+            
+
         # ----- Compiler parameters (default) -----
         # Base option: LIB enables the COPY statement.
         # Conditional suffixes are appended at build time:


### PR DESCRIPTION
This add's two new capabilities:

* The configuration allows users to set the default Zowe profile for executing the remote commands via Zowe CLI
* Sets the build order for the statically called submodules - `EMLVALID.cbl`