### PR TITLE
Fix setup script errors

### DIFF
--- a/.setup/setup/setup-cics-region.sh
+++ b/.setup/setup/setup-cics-region.sh
@@ -145,7 +145,10 @@ else
     exit 1
 fi
 
-deactivate
+# Deactivate virtual environment only if it was activated
+if type deactivate &>/dev/null; then
+    deactivate
+fi
 
 # =========================
 # Stage 4: Start CICS region

--- a/.setup/setup/setup-zosconnect-server.sh
+++ b/.setup/setup/setup-zosconnect-server.sh
@@ -24,7 +24,7 @@ source "$SCRIPTS_DIR/../config/setenv.sh"
 export ZOSCONNECT_HOME=$(get_section_value 'zosconnect' 'zosconnect_home')
 export ZOSCONNECT_HOME=$(echo "$ZOSCONNECT_HOME" | sed "s|~|$HOME|g")
 export CICS_USER=${CICS_USER:-$(get_section_value 'cics' 'user')}
-export CICS_PASSWORD=${CICS_PASSWORD:-$(get_section_value 'cics' 'password')}
+export CICS_PASSWORD=${CICS_PASSWORD:-$(get_section_value 'cics' 'password')}  # pragma: allowlist secret
 export JAVA_HOME=$(get_section_value 'zconfig' 'java_home')
 export ZOAU_HOME=${ZOAU_HOME:-$(get_section_value 'zoau' 'zoau_home')}
 export CICS_IPIC_PORT=$(get_section_value 'cics' 'ipic_port')
@@ -99,8 +99,12 @@ JVM_OPTIONS=-Xmx2048M
 //*
 EOF
 
-# Convert to EBCDIC
-a2e -f ISO8859-1 -t IBM-1047 "/tmp/BAQ${APP_BASE_NAME}.jcl"
+# Pad each line to exactly 80 characters for FB80 dataset
+awk '{printf "%-80s\n", substr($0, 1, 80)}' "/tmp/BAQ${APP_BASE_NAME}.jcl" > "/tmp/BAQ${APP_BASE_NAME}.jcl.padded"
+mv "/tmp/BAQ${APP_BASE_NAME}.jcl.padded" "/tmp/BAQ${APP_BASE_NAME}.jcl"
+
+# Convert to EBCDIC (force conversion even if already tagged)
+a2e -f ISO8859-1 -t IBM-1047 -F "/tmp/BAQ${APP_BASE_NAME}.jcl"
 
 # Copy to PROCLIB using dcp
 print_info "${CYAN}[ZOSCONNECT]${NC} Copying JCL to SYS1.PROCLIB..."


### PR DESCRIPTION
## Summary
This PR fixes three critical issues in the Bank of Z setup scripts that were preventing successful installation via the setup-common environment flow

## Changes
1. **setup-cics-region.sh**: Made `deactivate` call conditional to prevent errors when zconfig virtual environment isn't found
2. **setup-zosconnect-server.sh**: 
   - Added `-F` flag to force EBCDIC conversion on subsequent runs (fixes BGYSC5703E error)
   - Added proper 80-character line padding for FB80 PROCLIB dataset format (fixes EDC5003I truncation error)
   - Added pragma comment to allow CICS_PASSWORD environment variable (fixes pre-commit hook)

## Testing
These fixes resolve the following errors encountered during GRUB workflow execution:
- `deactivate: command not found` error
- `BGYSC5703E Not converting file as it is already tagged as EBCDIC` error
- `EDC5003I Truncation of a record occurred during an I/O operation` error

## Related Documentation
- [README.md(docs/README.md)