### PR TITLE
Ensure drm ${APP_BASE_NAME}.${APP_VERSION}.* completed before alloc

### DIFF
--- a/.setup/setup/setup-cics-region.sh
+++ b/.setup/setup/setup-cics-region.sh
@@ -43,7 +43,7 @@ set +e
 jcan P "CICS${APP_SHORT_NAME}" & 2>/dev/null
 opercmd "C CICS${APP_SHORT_NAME}" & 2>/dev/null
 sleep 10
-drm "${APP_BASE_NAME}.${APP_VERSION}.*" & 2>/dev/null
+drm "${APP_BASE_NAME}.${APP_VERSION}.*" 2>/dev/null
 drm "${APP_BASE_NAME}.CICS${APP_SHORT_NAME}.*" & 2>/dev/null
 drm "${APP_BASE_NAME}.DBB.*" & 2>/dev/null
 sleep 5


### PR DESCRIPTION
https://github.com/IBM/Bank-of-Z/blob/1b6645bd590b1cbe48dbf7dacebc5f525578daff/.setup/setup/setup-cics-region.sh#L49 I have noticed in slower zVDT instance, script failed at this line. 
I suspect it might be the earlier command to `drm "${APP_BASE_NAME}.${APP_VERSION}.*"` is not totally complete yet. 
Not having it as background process will ensure completion of the command when the script proceed to allocate for the load library. 
