### PR TITLE
Ensure drm ${APP_BASE_NAME}.${APP_VERSION}.* completed before alloc

### DIFF
--- a/.setup/setup-common.sh
+++ b/.setup/setup-common.sh
@@ -244,7 +244,10 @@ stage_setup_cics_region() {
     cd "$BANK_DIR"
     
     set -o pipefail
-    if  .setup/setup/setup-cics-region.sh; then
+    ./setup/setup/stage_setup_cics_region.sh &
+    PID=$!
+    # Wait for cics setup to complete (ZOAU/ZOWE ISSUE)
+    if wait "$PID"; then
         print_success "Bank of Z application setup completed successfully"
     else
         print_error "Failed to install Bank of Z"

--- a/.setup/setup/setup-cics-region.sh
+++ b/.setup/setup/setup-cics-region.sh
@@ -40,12 +40,12 @@ export LIBPATH="$ZOAU_HOME/lib:${LIBPATH:-}"
 # Ignore errors if already cancelled
 # =========================
 set +e
-jcan P "CICS${APP_SHORT_NAME}" & 2>/dev/null
-opercmd "C CICS${APP_SHORT_NAME}" & 2>/dev/null
+jcan P "CICS${APP_SHORT_NAME}"  2>/dev/null
+opercmd "C CICS${APP_SHORT_NAME}"  2>/dev/null
 sleep 10
 drm "${APP_BASE_NAME}.${APP_VERSION}.*" 2>/dev/null
-drm "${APP_BASE_NAME}.CICS${APP_SHORT_NAME}.*" & 2>/dev/null
-drm "${APP_BASE_NAME}.DBB.*" & 2>/dev/null
+drm "${APP_BASE_NAME}.CICS${APP_SHORT_NAME}.*"  2>/dev/null
+drm "${APP_BASE_NAME}.DBB.*"  2>/dev/null
 sleep 5
 tsocmd "ALLOC DA('${APP_BASE_NAME}.${APP_VERSION}.LOADLIB') NEW CATALOG DSNTYPE(LIBRARY) DSORG(PO) RECFM(U) BLKSIZE(32760) SPACE(5,5) CYL DIR(20)"
 # =========================
@@ -158,7 +158,7 @@ deactivate
 # =========================
 print_stage "STAGE 4: Start CICS region"
 
-jsub "${APP_BASE_NAME}.CICS${APP_SHORT_NAME}.DFHSTART" &
+jsub "${APP_BASE_NAME}.CICS${APP_SHORT_NAME}.DFHSTART" 
 sleep 10
 print_info "${CYAN}[ZCONFIG-INSTALL]${NC} CICS Region Job Started"
 sleep 10

--- a/.setup/setup/setup-cics-region.sh
+++ b/.setup/setup/setup-cics-region.sh
@@ -43,7 +43,7 @@ set +e
 jcan P "CICS${APP_SHORT_NAME}" & 2>/dev/null
 opercmd "C CICS${APP_SHORT_NAME}" & 2>/dev/null
 sleep 10
-drm "${APP_BASE_NAME}.${APP_VERSION}.*" & 2>/dev/null
+drm "${APP_BASE_NAME}.${APP_VERSION}.*" 2>/dev/null
 drm "${APP_BASE_NAME}.CICS${APP_SHORT_NAME}.*" & 2>/dev/null
 drm "${APP_BASE_NAME}.DBB.*" & 2>/dev/null
 sleep 5


### PR DESCRIPTION
https://github.com/IBM/Bank-of-Z/blob/1b6645bd590b1cbe48dbf7dacebc5f525578daff/.setup/setup/setup-cics-region.sh#L49 
I have noticed in slower zVDT instance, script failed at this line. (Reported in issue: https://github.com/IBM/Bank-of-Z/issues/56) 
I suspect it might be the earlier command to `drm "${APP_BASE_NAME}.${APP_VERSION}.*"` is not totally complete yet. 
Not having it as background process will ensure completion of the command when the script proceed to allocate for the load library. 