### PR TITLE
Fix CICS region setup script path

### DIFF
--- a/.setup/setup-common.sh
+++ b/.setup/setup-common.sh
@@ -244,7 +244,7 @@ stage_setup_cics_region() {
     cd "$BANK_DIR"
     
     set -o pipefail
-    ./setup/setup/stage_setup_cics_region.sh &
+    .setup/setup/setup-cics-region.sh &
     PID=$!
     # Wait for cics setup to complete (ZOAU/ZOWE ISSUE)
     if wait "$PID"; then


### PR DESCRIPTION
- Corrected path from './setup/setup/stage_setup_cics_region.sh' to '.setup/setup/setup-cics-region.sh'
- Bug introduced in commit d52af8c
- The file 'stage_setup_cics_region.sh' does not exist
- Fixes error: EDC5129I No such file or directory