### PR TITLE
Fix: Use SANDBOX_DIR variable instead of hard-coded path for WLP_USER…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ zowe.config.user.json
 vsix-extensions/
 *.vsix
 /.taz-unit-test
+tools/
+imsbank_provisioning/

--- a/.setup/setup/setup-zosconnect-server.sh
+++ b/.setup/setup/setup-zosconnect-server.sh
@@ -99,7 +99,7 @@ cat > "/tmp/BAQ${APP_BASE_NAME}.jcl" << 'EOF'
 //STDENV   DD   *
 _BPX_SHAREAS=YES
 JAVA_HOME=/usr/lpp/java/java21/current_64
-WLP_USER_DIR=/usr/local/sandboxes/bank-of-z/zosconnect-server
+WLP_USER_DIR=${SANDBOX_DIR}/zosconnect-server
 JVM_OPTIONS=-Xmx2048M
 //*
 // PEND


### PR DESCRIPTION
…_DIR in JCL

The WLP_USER_DIR in the z/OS Connect JCL proc was hard-coded to /usr/local/sandboxes/bank-of-z/zosconnect-server instead of using the configurable SANDBOX_DIR variable from config.yaml.

This change makes the setup portable across different environments by using ${SANDBOX_DIR}/zosconnect-server which resolves to the sandbox.path value defined in the configuration.