### PR TITLE
Fix: Enable shell variable expansion in JCL generation for WLP_USER_DIR

### DIFF
--- a/.setup/setup/setup-zosconnect-server.sh
+++ b/.setup/setup/setup-zosconnect-server.sh
@@ -82,7 +82,7 @@ print_info "${CYAN}[ZOSCONNECT]${NC} Generating JCL proc..."
 # Generate server JCL proc
 # =========================
 # Create JCL with each line padded to exactly 80 characters for FB80 dataset
-cat > "/tmp/BAQ${APP_BASE_NAME}.jcl" << 'EOF'
+cat > "/tmp/BAQ${APP_BASE_NAME}.jcl" << EOF
 //BAQBANKZ  PROC PARMS='bankzServer --clean'
 //*
 //* z/OS Connect Enterprise Edition 3.0.0


### PR DESCRIPTION
Changed heredoc delimiter from << 'EOF' to << EOF to allow shell variable expansion. This ensures ${SANDBOX_DIR} is replaced with the actual sandbox path value when generating the JCL proc.

Without this fix, the literal string ${SANDBOX_DIR} was written to the JCL, causing z/OS Connect to fail with 'server does not exist' error because it couldn't resolve the path.

Now the JCL will contain the actual path from config.yaml, making the setup portable across different environments.