### PR TITLE
Direct YAML files to Dummy scanner 

### DIFF
--- a/dbb-app.yaml
+++ b/dbb-app.yaml
@@ -20,6 +20,14 @@ application:
   name: BANKZ
 
   tasks:
+
+    - task: ScannerInit
+      variables:
+        - name: scanners
+          value: 
+            - scanner: Dummy # Direct yaml files for z/OS Connect files to the Dummy scanner instead of the default DBB DependencyScanner
+              extensions: yaml
+
       # Variable overrides for the FullAnalysis task
     - task: FullAnalysis
       variables:

--- a/dbb-app.yaml
+++ b/dbb-app.yaml
@@ -289,8 +289,6 @@ application:
             - "**/src/main/api/openapi.yaml"
         - name: gradleDebug
           value: true
-        - name: gradleDebug
-          value: true
         - name: gradlePath
           value: "/usr/local/sandboxes/tools/gradle-9.5.1/bin/gradle"
         - name: shellEnvironment

--- a/dbb-app.yaml
+++ b/dbb-app.yaml
@@ -17,7 +17,7 @@
 version: 1.0.0
 
 application:
-  name: Bank-of-Z
+  name: BANKZ
 
   tasks:
 
@@ -26,9 +26,9 @@ application:
       # Configure the source directory for building
       - name: sourceDirs
         value:
-            - "${APPLICATION}/src/base"
-            - "${APPLICATION}/src/api/src/main/api"
-            - "${APPLICATION}/src/frontend"
+            - "Bank-of-Z/src/base"
+            - "Bank-of-Z/src/api/src/main/api"
+            - "Bank-of-Z/src/frontend"
 
     - task: ScannerInit
       variables:

--- a/dbb-app.yaml
+++ b/dbb-app.yaml
@@ -17,45 +17,35 @@
 version: 1.0.0
 
 application:
-  name: BANKZ
+  name: Bank-of-Z
 
   tasks:
+
+    - task: Start
+      variables:
+      # Configure the source directory for building
+      - name: sourceDirs
+        value:
+            - "${APPLICATION}/src/base"
+            - "${APPLICATION}/src/api/src/main/api"
+            - "${APPLICATION}/src/frontend"
 
     - task: ScannerInit
       variables:
         - name: scanners
-          value: 
-            - scanner: Dummy # Direct yaml files for z/OS Connect files to the Dummy scanner instead of the default DBB DependencyScanner
+          value:
+            - scanner: Dummy
               extensions: yaml
+        - name: excludeFileList
+          value: [".*","**/.*","**.html","**.java","**.png","**.css","**.js","**.groovy","**.json","**.md","**.java","**/LoadData/**"]  
 
       # Variable overrides for the FullAnalysis task
     - task: FullAnalysis
       variables:
-        - name: sourceDirs
-          value:
-            - "src/base"
-            - "src/api/src/main/api"
-            - "src/frontend"
         - name: continueOnScanFailure
           value: true
         - name: excludeFileList
-          value:
-            - ".**"
-            - "**/.**"
-            - "**.properties"
-            - "**.groovy"
-            - "**.json"
-            - "**.md"
-            - "**.sh"
-            - "**.jcl"
-            - "**.tar"
-            - "**.war"
-            - "**.log"
-            - "**/operations/**"
-            - "**/zosAssets/**"
-            - "**/dbb-app.yaml"
-            - "**/zapp.yaml"
-            - "**/docker-compose.yaml"
+          value: [".*","**/.*","**.html","**.java","**.png","**.css","**.js","**.groovy","**.json","**.md","**.java","**/LoadData/**"]
 
     # ----------------------------------------------------------
     # ImpactAnalysis task
@@ -65,33 +55,12 @@ application:
     # ----------------------------------------------------------
     - task: ImpactAnalysis
       variables:
-        - name: sourceDirs
-          value:
-            - "src/base"
-            - "src/api/src/main/api"
-            - "src/frontend"
-        
         - name: continueOnScanFailure
           value: true
-        
+
         - name: excludeFileList
-          value:
-            - ".**"
-            - "**/.**"
-            - "**.properties"
-            - "**.groovy"
-            - "**.json"
-            - "**.md"
-            - "**.sh"
-            - "**.jcl"
-            - "**.tar"
-            - "**.war"
-            - "**.log"
-            - "**/operations/**"
-            - "**/zosAssets/**"
-            - "**/dbb-app.yaml"
-            - "**/zapp.yaml"
-            - "**/docker-compose.yaml"
+          value: [".*","**/.*","**.html","**.java","**.png","**.css","**.js","**.groovy","**.json","**.md","**.java","**/LoadData/**"]
+
         
         # Uncomment to log every file scanned during analysis:
         #- name: printScannedItems
@@ -314,10 +283,9 @@ application:
           value: "src/api/src/main/liberty/config/cics.xml"
     
     - task: zOSConnect
+      sources:
+        - "**/src/main/api/openapi.yaml"
       variables:
-        - name: configSources
-          value:
-            - "**/src/main/api/openapi.yaml"
         - name: gradleDebug
           value: true
         - name: gradlePath

--- a/dbb-app.yaml
+++ b/dbb-app.yaml
@@ -283,9 +283,12 @@ application:
           value: "src/api/src/main/liberty/config/cics.xml"
     
     - task: zOSConnect
-      sources:
-        - "**/src/main/api/openapi.yaml"
       variables:
+        - name: configSources
+          value:
+            - "**/src/main/api/openapi.yaml"
+        - name: gradleDebug
+          value: true
         - name: gradleDebug
           value: true
         - name: gradlePath


### PR DESCRIPTION
This configures the build to only look for files in the `src` folders and configure the dbb scanners for YAML 