### PR TITLE
Use example domain instead of bankofz.com

### DIFF
--- a/src/api/src/main/api/openapi.yaml
+++ b/src/api/src/main/api/openapi.yaml
@@ -7,7 +7,7 @@ info:
   version: 1.0.0
   contact:
     name: Bank of Z API Support
-    email: api-support@bankofz.com
+    email: api-support@bankofz.example.com
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
@@ -466,8 +466,8 @@ components:
       description: OAuth2 authentication for secure API access
       flows:
         authorizationCode:
-          authorizationUrl: https://auth.bankofz.com/oauth/authorize
-          tokenUrl: https://auth.bankofz.com/oauth/token
+          authorizationUrl: https://auth.bankofz.example.com/oauth/authorize
+          tokenUrl: https://auth.bankofz.example.com/oauth/token
           scopes:
             accounts: Access to account information
             customers: Access to customer information

--- a/src/api/src/main/operations/%2Fims%2Fcustomers%2F%7BcustomerId%7D/get/response_200.yaml
+++ b/src/api/src/main/operations/%2Fims%2Fcustomers%2F%7BcustomerId%7D/get/response_200.yaml
@@ -18,7 +18,7 @@ mappings:
     - email:
         required: true
         nullable: false
-        template: "customer@bankofz.com"
+        template: "customer@bankofz.example.com"
     - phoneNumber:
         required: false
         nullable: false


### PR DESCRIPTION
Reserved names should be used to avoid conflict,— see https://www.iana.org/help/example-domains