### PR TITLE
Perform catalog populate only for PSB/DBD

### DIFF
--- a/.setup/deploy/deployment-method.yml
+++ b/.setup/deploy/deployment-method.yml
@@ -357,6 +357,9 @@ activities:
             properties:
             - key: "template"
               value: "ims_catalog_populate"
+    types:
+      - name: 'PSBLOAD'
+      - name: 'DBDLOAD'
     is_artifact: False
     tags:
     - ims_catalog_management


### PR DESCRIPTION
Perform catalog populate must be done only if we have PSB/DBD in pipeline update mode.