### PR TITLE
Deploy frontend to standalone liberty instance

### DIFF
--- a/.setup/config/config.yaml
+++ b/.setup/config/config.yaml
@@ -89,6 +89,14 @@ zosconnect:
   http_port: 9080
   https_port: 9443
 
+# Frontend Liberty Server (separate from z/OS Connect)
+frontend:
+  liberty_home: "/usr/lpp/liberty_zos/25.0.0.9"
+  server_dir: "{{sandbox.path}}/frontend"
+  server_name: "bankz-frontend"
+  http_port: 9081
+  https_port: 9444
+
 # ZOAU installation directory
 zoau:
   zoau_home: "/usr/lpp/IBM/zoautil"

--- a/.setup/deploy/Development.yml
+++ b/.setup/deploy/Development.yml
@@ -63,6 +63,12 @@ cics_port: "{{ extra_vars.cics_port if extra_vars.cics_port is defined else '200
 cics_user: "{{ extra_vars.cics_user if extra_vars.cics_user is defined else 'IBMUSER' }}"
 cics_password: "{{ extra_vars.cics_password if extra_vars.cics_password is defined else '' }}" #pragma: allowlist secret
 
+# Frontend Liberty Server (separate from z/OS Connect)
+frontend_root: "{{ extra_vars.frontend_root if extra_vars.frontend_root is defined else sandbox_path + '/frontend' }}"
+frontend_server_name: "{{ extra_vars.frontend_server_name if extra_vars.frontend_server_name is defined else 'bankz-frontend' }}"
+frontend_job_name: "{{ extra_vars.frontend_job_name if extra_vars.frontend_job_name is defined else 'FEBANKZ' }}"
+frontend_http_port: "{{ extra_vars.frontend_http_port if extra_vars.frontend_http_port is defined else '9081' }}"
+
 template_name_zosconnect_config:
   src: '../deploy/zos_connect_app_config.xml.j2'
   dest: '{{zos_connect_root}}/configDropins/overrides/{{api_name}}.xml'
@@ -85,6 +91,19 @@ system_command_refresh_config:
 
 system_command_refresh_apps:
   cmd: 'MODIFY {{zos_connect_job_name}},REFRESH,APPS'
+  verbose: false
+  wait_time_s: 3
+  wait: true
+
+# System commands for Frontend Liberty server management
+system_command_start_frontend:
+  cmd: 'S {{frontend_job_name}}'
+  verbose: false
+  wait_time_s: 5
+  wait: true
+
+system_command_stop_frontend:
+  cmd: 'C {{frontend_job_name}}'
   verbose: false
   wait_time_s: 3
   wait: true

--- a/.setup/deploy/types_pattern_mapping.yml
+++ b/.setup/deploy/types_pattern_mapping.yml
@@ -89,17 +89,17 @@ types:
      directory_backup: "{{ uss_root }}/sh/back/"
      dest_mode: 0777
      artifact_mode: 0755
-  - pattern: .*\.WAR$
-    uss:
-       dest: '{{zos_connect_root}}/apps'
-       backup_dest: '{{zos_connect_root}}/backup/apps'
-       mode: 0755
-    mode: 0777
-    is_binary: True
   - pattern: .*-frontend.*\.WAR$
     uss:
        dest: '{{frontend_root}}/servers/{{frontend_server_name}}/apps'
        backup_dest: '{{frontend_root}}/backup/apps'
+       mode: 0755
+    mode: 0777
+    is_binary: True
+  - pattern: ^(?!.*-frontend).*\.WAR$
+    uss:
+       dest: '{{zos_connect_root}}/apps'
+       backup_dest: '{{zos_connect_root}}/backup/apps'
        mode: 0755
     mode: 0777
     is_binary: True

--- a/.setup/deploy/types_pattern_mapping.yml
+++ b/.setup/deploy/types_pattern_mapping.yml
@@ -96,6 +96,13 @@ types:
        mode: 0755
     mode: 0777
     is_binary: True
+  - pattern: .*-frontend.*\.WAR$
+    uss:
+       dest: '{{frontend_root}}/servers/{{frontend_server_name}}/apps'
+       backup_dest: '{{frontend_root}}/backup/apps'
+       mode: 0755
+    mode: 0777
+    is_binary: True
   - pattern: .*\.IMSLOAD$
     pds:
       name: "{{ ims_hlq }}.{{ ims_datastore }}.PGMLIB"

--- a/.setup/setup-common.sh
+++ b/.setup/setup-common.sh
@@ -347,6 +347,32 @@ stage_setup_zosconnect_server() {
     fi
 
 }
+#########################################################
+# STAGE: Setup Frontend Liberty server
+#########################################################
+stage_setup_frontend_server() {
+    print_stage "STAGE: Setup Frontend Liberty server"
+
+    if [ ! -f "$BANK_DIR/.setup/setup/setup-frontend-server.sh" ]; then
+        print_error "Installation script not found: $BANK_DIR/.setup/setup/setup-frontend-server.sh"
+        exit 1
+    fi
+    
+    # Run script
+    print_info "Running Bank of Z Frontend Liberty server setup script..."
+    print_info "Executing: bash $BANK_DIR/.setup/setup/setup-frontend-server.sh"
+    cd "$BANK_DIR"
+    
+    set -o pipefail
+    if bash .setup/setup/setup-frontend-server.sh; then
+        print_success "Frontend Liberty server setup completed successfully"
+    else
+        print_error "Failed to setup Frontend Liberty server"
+        exit 1
+    fi
+
+}
+
 
 
 #########################################################
@@ -469,6 +495,8 @@ main_setup() {
     stage_setup_ims_bankz_regions
     
     stage_setup_zosconnect_server
+    
+    stage_setup_frontend_server
     
     # Summary
     print_stage "SETUP COMPLETE"

--- a/.setup/setup/setup-frontend-server.sh
+++ b/.setup/setup/setup-frontend-server.sh
@@ -1,0 +1,207 @@
+#!/bin/env bash
+set -e
+# =============================================================================
+# Script  : setup-frontend-server.sh
+# Summary : Create and configure Frontend Liberty Server
+#
+# Runs on the remote z/OS USS system after the workspace has been cloned.
+# - Creates Liberty server instance for frontend
+# - Configures RACF STARTED profile
+# - Generates server JCL proc in SYS1.PROCLIB
+# - Configures server to proxy API requests to z/OS Connect
+#
+# NOTE: Deployment of WAR files is handled by Wazi Deploy
+# =============================================================================
+
+# =========================
+# Source library scripts
+# =========================
+SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPTS_DIR/../config/setenv.sh"
+
+# =========================
+# Environment
+# =========================
+export LIBERTY_HOME=$(get_section_value 'frontend' 'liberty_home')
+export LIBERTY_HOME=$(echo "$LIBERTY_HOME" | sed "s|~|$HOME|g")
+export JAVA_HOME=$(get_section_value 'java' 'java_home')
+export ZOAU_HOME=${ZOAU_HOME:-$(get_section_value 'zoau' 'zoau_home')}
+export FRONTEND_HTTP_PORT=$(get_section_value 'frontend' 'http_port')
+export FRONTEND_HTTPS_PORT=$(get_section_value 'frontend' 'https_port')
+export ZOSCONNECT_HTTP_PORT=$(get_section_value 'zosconnect' 'http_port')
+
+export PATH="$ZOAU_HOME/bin:$PATH"
+export LIBPATH="$ZOAU_HOME/lib:${LIBPATH:-}"
+
+export WLP_USER_DIR="${SANDBOX_DIR}/frontend"
+export SERVER_NAME="${APP_BASE_NAME_LOWER}-frontend"
+
+# =========================
+# Create Frontend Liberty server
+# =========================
+print_stage "Create Frontend Liberty Server"
+print_info "${CYAN}[FRONTEND]${NC} Creating Liberty server at: $WLP_USER_DIR"
+
+if [ -d "$WLP_USER_DIR" ]; then
+    print_warning "Removing existing server at $WLP_USER_DIR"
+    rm -rf "$WLP_USER_DIR"
+fi
+
+# Create server directory structure
+mkdir -p "$WLP_USER_DIR/servers"
+
+# Create the server using Liberty's server command
+"${LIBERTY_HOME}/bin/server" create "${SERVER_NAME}" --template=defaultServer
+
+# Move server to our WLP_USER_DIR
+if [ -d "${LIBERTY_HOME}/usr/servers/${SERVER_NAME}" ]; then
+    mv "${LIBERTY_HOME}/usr/servers/${SERVER_NAME}" "${WLP_USER_DIR}/servers/"
+fi
+
+RC=$?
+if [ $RC -eq 0 ]; then
+    print_success "Frontend Liberty server created successfully at $WLP_USER_DIR"
+else
+    print_error "Failed to create Frontend Liberty server (RC=$RC)"
+    exit 1
+fi
+
+# =========================
+# Configure server.xml
+# =========================
+print_info "${CYAN}[FRONTEND]${NC} Configuring server.xml..."
+
+cat > "${WLP_USER_DIR}/servers/${SERVER_NAME}/server.xml" << 'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<server description="Bank of Z Frontend Server">
+
+    <!-- Enable features -->
+    <featureManager>
+        <feature>servlet-6.0</feature>
+        <feature>jsp-3.1</feature>
+        <feature>transportSecurity-1.0</feature>
+    </featureManager>
+
+    <!-- HTTP Endpoint Configuration -->
+    <httpEndpoint id="defaultHttpEndpoint"
+                  httpPort="${frontend.http.port}"
+                  httpsPort="${frontend.https.port}"
+                  host="*" />
+
+    <!-- Application Configuration -->
+    <webApplication id="bank-frontend" 
+                    location="${server.config.dir}/apps/bank-frontend-vanilla.war" 
+                    name="bank-frontend" 
+                    contextRoot="/">
+        <classloader delegation="parentLast" />
+    </webApplication>
+
+    <!-- Logging Configuration -->
+    <logging traceSpecification="*=info" 
+             maxFileSize="20" 
+             maxFiles="10" />
+
+    <!-- SSL Configuration (optional - for HTTPS) -->
+    <keyStore id="defaultKeyStore" password="Liberty" />
+
+</server>
+EOF
+
+# =========================
+# Create bootstrap.properties
+# =========================
+print_info "${CYAN}[FRONTEND]${NC} Creating bootstrap.properties..."
+
+cat > "${WLP_USER_DIR}/servers/${SERVER_NAME}/bootstrap.properties" << EOF
+# Frontend Liberty Server Bootstrap Properties
+frontend.http.port=${FRONTEND_HTTP_PORT}
+frontend.https.port=${FRONTEND_HTTPS_PORT}
+zosconnect.http.port=${ZOSCONNECT_HTTP_PORT}
+EOF
+
+# =========================
+# Configure RACF STARTED profile
+# =========================
+print_info "${CYAN}[FRONTEND]${NC} Configuring RACF STARTED profile..."
+set +e
+opercmd "C FE${APP_BASE_NAME}" 2>/dev/null &
+sleep 5
+print_info "${CYAN}[FRONTEND]${NC} Defining RACF STARTED class..."
+tsocmd "RDEFINE STARTED FE${APP_BASE_NAME}.* STDATA(USER(${ZOS_USER}) TRUSTED(YES))" 2>/dev/null
+print_info "${CYAN}[FRONTEND]${NC} Refreshing RACF..."
+tsocmd "SETROPTS RACLIST(STARTED) REFRESH" 2>/dev/null
+print_info "${CYAN}[FRONTEND]${NC} Removing old PROCLIB member..."
+mrm "SYS1.PROCLIB(FE${APP_BASE_NAME})" 2>/dev/null || true
+set -e
+print_info "${CYAN}[FRONTEND]${NC} Generating JCL proc..."
+
+# =========================
+# Generate server JCL proc
+# =========================
+# Create JCL with each line padded to exactly 80 characters for FB80 dataset
+cat > "/tmp/FE${APP_BASE_NAME}.jcl" << EOF
+//FEBANKZ  PROC PARMS='${SERVER_NAME}'
+//*
+//* WebSphere Liberty - Frontend Server
+//* Bank of Z Frontend Application Server
+//*
+// SET LIBHOME='${LIBERTY_HOME}'
+//*
+//FEBANKZ     EXEC PGM=BPXBATSL,REGION=0M,MEMLIMIT=2G,
+//    TIME=NOLIMIT,
+//    PARM='PGM &LIBHOME./bin/server run &PARMS.'
+//STDOUT   DD   SYSOUT=*
+//STDERR   DD   SYSOUT=*
+//STDIN    DD   DUMMY
+//STDENV   DD   *
+_BPX_SHAREAS=YES
+JAVA_HOME=${JAVA_HOME}
+WLP_USER_DIR=${WLP_USER_DIR}
+JVM_OPTIONS=-Xmx1024M
+//*
+// PEND
+//*
+EOF
+
+# Convert to EBCDIC
+a2e -f ISO8859-1 -t IBM-1047 "/tmp/FE${APP_BASE_NAME}.jcl"
+
+# Copy to PROCLIB using dcp
+print_info "${CYAN}[FRONTEND]${NC} Copying JCL to SYS1.PROCLIB..."
+dcp "/tmp/FE${APP_BASE_NAME}.jcl" "SYS1.PROCLIB(FE${APP_BASE_NAME})"
+
+# Clean up temp files
+rm -f "/tmp/FE${APP_BASE_NAME}.jcl"
+
+# =========================
+# Create apps directory
+# =========================
+print_info "${CYAN}[FRONTEND]${NC} Creating apps directory..."
+mkdir -p "${WLP_USER_DIR}/servers/${SERVER_NAME}/apps"
+
+# =========================
+# Start the server
+# =========================
+print_info "${CYAN}[FRONTEND]${NC} Starting frontend server..."
+opercmd "S FE${APP_BASE_NAME}" 2>/dev/null &
+sleep 5
+
+print_success "Frontend Liberty server setup completed"
+print_info ""
+print_info "Frontend Server Details:"
+print_info "  Server Name: ${SERVER_NAME}"
+print_info "  Server Directory: ${WLP_USER_DIR}/servers/${SERVER_NAME}"
+print_info "  HTTP Port: ${FRONTEND_HTTP_PORT}"
+print_info "  HTTPS Port: ${FRONTEND_HTTPS_PORT}"
+print_info "  Started Task: FE${APP_BASE_NAME}"
+print_info "  PROCLIB Member: SYS1.PROCLIB(FE${APP_BASE_NAME})"
+print_info ""
+print_info "To access the frontend:"
+print_info "  http://localhost:${FRONTEND_HTTP_PORT}/"
+print_info ""
+print_info "To manage the server:"
+print_info "  Start:  S FE${APP_BASE_NAME}"
+print_info "  Stop:   C FE${APP_BASE_NAME}"
+print_info ""
+
+# Made with Bob

--- a/.setup/setup/setup-zosconnect-server.sh
+++ b/.setup/setup/setup-zosconnect-server.sh
@@ -28,6 +28,7 @@ export CICS_PASSWORD=${CICS_PASSWORD:-$(get_section_value 'cics' 'password')} #p
 export JAVA_HOME=$(get_section_value 'zconfig' 'java_home')
 export ZOAU_HOME=${ZOAU_HOME:-$(get_section_value 'zoau' 'zoau_home')}
 export CICS_IPIC_PORT=$(get_section_value 'cics' 'ipic_port')
+export FRONTEND_HTTP_PORT=$(get_section_value 'frontend' 'http_port')
 
 # IMS environment variables
 export IMS_HOST=${IMS_HOST:-$(get_section_value 'ims' 'host')}
@@ -147,6 +148,26 @@ cat > "${WLP_USER_DIR}/servers/${APP_BASE_NAME_LOWER}Server/configDropins/overri
     </connectionFactory>
 
     <authData id="IMSCredentials" user="${IMS_USER}" password="${IMS_PASSWORD}" />
+</server>
+EOF
+
+# =========================
+# Configure CORS for frontend server
+# =========================
+cat > "${WLP_USER_DIR}/servers/${APP_BASE_NAME_LOWER}Server/configDropins/overrides/cors.xml" << EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<server description="CORS configuration for frontend server">
+    <featureManager>
+        <feature>cors-1.0</feature>
+    </featureManager>
+    
+    <!-- Allow requests from frontend Liberty server on port ${FRONTEND_HTTP_PORT} -->
+    <cors domain="/api"
+          allowedOrigins="http://localhost:${FRONTEND_HTTP_PORT}, http://127.0.0.1:${FRONTEND_HTTP_PORT}, http://*:${FRONTEND_HTTP_PORT}"
+          allowedMethods="GET, POST, PUT, DELETE, OPTIONS"
+          allowedHeaders="*"
+          allowCredentials="true"
+          maxAge="3600" />
 </server>
 EOF
 

--- a/src/frontend/config.js
+++ b/src/frontend/config.js
@@ -10,7 +10,11 @@
 export const config = {
     api: {
         // Base URL for API endpoints
-        baseUrl: '/api'
+        // In production, this should point to the z/OS Connect server on port 9080
+        // The frontend is served from a separate Liberty server on port 9081
+        baseUrl: window.location.hostname === 'localhost'
+            ? 'http://localhost:9080/api'  // Local z/OS Connect server
+            : 'http://' + window.location.hostname + ':9080/api'  // Production z/OS Connect server
     },
     defaults: {
         sortCode: '987654'


### PR DESCRIPTION
This migrates the frontend application deployment from the z/OS connect server to it's own standard liberty instance. It's all configured in the config.yaml, like everything else, and lifecycles the same as the zosconnect instance.

API is still on `:9080/api` by default.
Frontend is `:9081` by default.

`http://<host>:9081/admin.html` queries `http://<host>:9080/api/customers/1234`