### PR TITLE
Add missing response_401 and response_403 mappings for POST /customers

### DIFF
--- a/src/api/src/main/operations/%2Fcustomers/post/response_401.yaml
+++ b/src/api/src/main/operations/%2Fcustomers/post/response_401.yaml
@@ -1,0 +1,13 @@
+---
+version: "1.2"
+mappings:
+- body:
+    mappings:
+    - code:
+        required: true
+        nullable: false
+        template: "UNAUTHORIZED"
+    - message:
+        required: true
+        nullable: false
+        template: "Authentication credentials are missing or invalid"

--- a/src/api/src/main/operations/%2Fcustomers/post/response_403.yaml
+++ b/src/api/src/main/operations/%2Fcustomers/post/response_403.yaml
@@ -1,0 +1,13 @@
+---
+version: "1.2"
+mappings:
+- body:
+    mappings:
+    - code:
+        required: true
+        nullable: false
+        template: "FORBIDDEN"
+    - message:
+        required: true
+        nullable: false
+        template: "You do not have permission to create customers"


### PR DESCRIPTION
Added response_401 and response_403 to remain consistent with other APIs and maintain good practice.