### PR TITLE
fix: stop server before rm to avoid CWWKE0045E on re-run

### DIFF
--- a/.setup/setup/setup-frontend-server.sh
+++ b/.setup/setup/setup-frontend-server.sh
@@ -30,7 +30,7 @@ export FRONTEND_HTTP_PORT=$(get_section_value 'frontend' 'http_port')
 export FRONTEND_HTTPS_PORT=$(get_section_value 'frontend' 'https_port')
 export ZOSCONNECT_HTTP_PORT=$(get_section_value 'zosconnect' 'http_port')
 
-export PATH="$ZOAU_HOME/bin:$PATH"
+export PATH="$JAVA_HOME/bin:$ZOAU_HOME/bin:$PATH"
 export LIBPATH="$ZOAU_HOME/lib:${LIBPATH:-}"
 
 export WLP_USER_DIR="${SANDBOX_DIR}/frontend"
@@ -44,25 +44,27 @@ print_info "${CYAN}[FRONTEND]${NC} Creating Liberty server at: $WLP_USER_DIR"
 
 if [ -d "$WLP_USER_DIR" ]; then
     print_warning "Removing existing server at $WLP_USER_DIR"
+    # Stop any running server first so z/OS releases locks on workarea files,
+    # otherwise rm -rf returns RC=0 but leaves the directory skeleton behind,
+    # causing CWWKE0045E on the subsequent 'server create'.
+    set +e
+    "${LIBERTY_HOME}/bin/server" stop "${SERVER_NAME}" 2>/dev/null
+    sleep 3
+    set -e
     rm -rf "$WLP_USER_DIR"
 fi
 
-# Remove any stale server Liberty may have created under its own usr/ directory
+# Remove any stale server Liberty may have created under its own default usr/ directory
 rm -rf "${LIBERTY_HOME}/usr/servers/${SERVER_NAME}"
 
-# Create the server using Liberty's server command (creates under LIBERTY_HOME/usr by default)
+# Create the server. WLP_USER_DIR is exported so Liberty places it directly
+# under ${WLP_USER_DIR}/servers/${SERVER_NAME} — no mv needed.
 "${LIBERTY_HOME}/bin/server" create "${SERVER_NAME}" --template=defaultServer
 
-# Move server to our WLP_USER_DIR
-if [ -d "${LIBERTY_HOME}/usr/servers/${SERVER_NAME}" ]; then
-    mv "${LIBERTY_HOME}/usr/servers/${SERVER_NAME}" "${WLP_USER_DIR}/servers/"
-fi
-
-RC=$?
-if [ $RC -eq 0 ]; then
+if [ $? -eq 0 ]; then
     print_success "Frontend Liberty server created successfully at $WLP_USER_DIR"
 else
-    print_error "Failed to create Frontend Liberty server (RC=$RC)"
+    print_error "Failed to create Frontend Liberty server"
     exit 1
 fi
 


### PR DESCRIPTION
On re-run the Liberty started task may still hold locks on files in workarea/, causing rm -rf to return RC=0 but leave the directory skeleton behind. A subsequent 'server create' then fails with CWWKE0045E because the server directory already exists.

```
=================================================================
= STAGE 10: Setup Frontend Liberty server
=================================================================

[INFO] Running Bank of Z Frontend Liberty server setup script...
[INFO] Executing: bash /usr/local/sandboxes/bank-of-z/Bank-of-Z/.setup/setup/setup-frontend-server.sh

=================================================================
= Create Frontend Liberty Server
=================================================================

[INFO] [FRONTEND] Creating Liberty server at: /usr/local/sandboxes/bank-of-z/frontend
[WARNING] Removing existing server at /usr/local/sandboxes/bank-of-z/frontend

CWWKE0005E: The runtime environment could not be launched.
CWWKE0045E: It was not possible to create the server called bankz-frontend because the server directory /usr/local/sandboxes/bank-of-z/frontend/servers/bankz-frontend already exists.
[ERROR] Failed to setup Frontend Liberty server
[ERROR] Failed to execute environment

```

Changes:
- Stop the running server (best-effort) before rm -rf so z/OS releases all file locks before the directory is removed
- Add JAVA_HOME/bin to PATH so 'server create' can find java regardless of the caller's environment
- Remove the dead mv block: with WLP_USER_DIR exported, Liberty creates the server directly under WLP_USER_DIR/servers/, never under LIBERTY_HOME/usr/servers/