### PR TITLE
frontend liberty server setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ scripts/update-frontend-file.sh
 scripts/update-frontend-file-zos.sh
 **/.taz-edt/
 **/datasets.yaml
+.gradle/

--- a/.setup/config/setenv.sh
+++ b/.setup/config/setenv.sh
@@ -35,7 +35,7 @@ fi
 set -e
 
 
-if [[ ! -f "$ENV_FILE" || "$ENV_FILE" -ot "$CONFIG_FILE" ]]; then
+if [[ ! -f "$ENV_FILE" || "$ENV_FILE" -ot "$CONFIG_FILE" || "$ENV_FILE" -ot "${BASH_SOURCE[0]}" ]]; then
     echo "Creating $ENV_FILE file - Not already exists or not in sync with config.yml ..."
     cat > "$ENV_FILE" <<EOF
 # =========================

--- a/.setup/setup/setup-frontend-server.sh
+++ b/.setup/setup/setup-frontend-server.sh
@@ -40,18 +40,18 @@ if [ -d "$WLP_USER_DIR" ]; then
     # otherwise rm -rf returns RC=0 but leaves the directory skeleton behind,
     # causing CWWKE0045E on the subsequent 'server create'.
     set +e
-    "${LIBERTY_HOME}/bin/server" stop "${SERVER_NAME}" 2>/dev/null
+    "${FRONTEND_LIBERTY_HOME}/bin/server" stop "${SERVER_NAME}" 2>/dev/null
     sleep 3
     set -e
     rm -rf "$WLP_USER_DIR"
 fi
 
 # Remove any stale server Liberty may have created under its own default usr/ directory
-rm -rf "${LIBERTY_HOME}/usr/servers/${SERVER_NAME}"
+rm -rf "${FRONTEND_LIBERTY_HOME}/usr/servers/${SERVER_NAME}"
 
 # Create the server. WLP_USER_DIR is exported so Liberty places it directly
 # under ${WLP_USER_DIR}/servers/${SERVER_NAME} — no mv needed.
-"${LIBERTY_HOME}/bin/server" create "${SERVER_NAME}" --template=defaultServer
+"${FRONTEND_LIBERTY_HOME}/bin/server" create "${SERVER_NAME}" --template=defaultServer
 
 if [ $? -eq 0 ]; then
     print_success "Frontend Liberty server created successfully at $WLP_USER_DIR"


### PR DESCRIPTION
fix: resolve FRONTEND_LIBERTY_HOME in frontend Liberty server setup

## Problem
Stage 11 fails with:
  setup-frontend-server.sh: line 54: /bin/server: EDC5129I No such file or directory

`FRONTEND_LIBERTY_HOME` is empty at runtime. Commit 7c1d5a9 renamed
`LIBERTY_HOME` → `FRONTEND_LIBERTY_HOME` and moved the export into
`setenv.sh`, but left 3 call-sites in `setup-frontend-server.sh` still
using the old name. Separately, the `.env` cache is only invalidated
when `config.yaml` changes — not when `setenv.sh` itself changes — so
systems with a cached `.env` from before 7c1d5a9 never pick up the new
variable.

## Changes
- `setup-frontend-server.sh`: replace 3 stale `LIBERTY_HOME` refs with `FRONTEND_LIBERTY_HOME`
- `setenv.sh`: add `|| "$ENV_FILE" -ot "${BASH_SOURCE[0]}"` to the staleness check so `.env` is regenerated whenever `setenv.sh` changes

## Testing
- Fresh env: stage 11 completes, server created at expected path
- Re-run: server stopped before `rm -rf`, no CWWKE0045E
- Stale `.env`: regenerated on first run, `FRONTEND_LIBERTY_HOME` populated correctly

Signed-off-by: Andrew Nguyen <andy.nguyen@ibm.com>