### PR TITLE
Use product name for zconfig and add to glossary

### DIFF
--- a/.setup/pipeline-common.sh
+++ b/.setup/pipeline-common.sh
@@ -125,7 +125,7 @@ print_usage() {
     echo "Usage: bash pipeline-common.sh <phase>"
     echo ""
     echo "Phases:"
-    echo "  validate-prereqs  Validate prerequisites (zConfig, DBB, wazi-deploy)"
+    echo "  validate-prereqs  Validate prerequisites (zconfig, DBB, wazi-deploy)"
     echo "  build             Build the Bank of Z baseline"
     echo "  deploy            Deploy the Bank of Z baseline"
     echo "  build-and-deploy  Build and deploy the Bank of Z updates"

--- a/.setup/setup-common.sh
+++ b/.setup/setup-common.sh
@@ -467,7 +467,7 @@ print_usage() {
     echo "Usage: bash setup-common.sh <phase>"
     echo ""
     echo "Phases:"
-    echo "  validate-prereqs  Validate prerequisites (zConfig, DBB, wazi-deploy)"
+    echo "  validate-prereqs  Validate prerequisites (zconfig, DBB, wazi-deploy)"
     echo "  environment       Initialize workspace and infrastructure prerequisites"
     echo "  install-bank-of-z Build and deploy the Bank of Z baseline"
     echo ""

--- a/docs/docs/installation-and-setup/prerequisites.md
+++ b/docs/docs/installation-and-setup/prerequisites.md
@@ -48,7 +48,7 @@ The following tools must be installed on z/OS USS. These are typically installed
 | IBM Python SDK | 3.14 | `python.python_home` |
 | IBM Dependency Based Build (DBB) | 3.0.5 | `dbb.dbb_home` |
 | Z Open Automation Utilities (ZOAU) | 1.4.1.0 | `zoau.zoau_home` |
-| zconfig | 0.6.0 | `zconfig.zconfig_home` |
+| z/OS Middleware Configuration Tool (zconfig) | 0.6.0 | `zconfig.zconfig_home` |
 | Wazi Deploy | 3.0.7.3 | `wazideploy.wazideploy_home` |
 | ZCodeScan | 1.0.2 | `zcodescan.zcodescan_home` |
 | Ansible | 2.15 | — |

--- a/docs/docs/reference/configuration-reference.md
+++ b/docs/docs/reference/configuration-reference.md
@@ -92,7 +92,7 @@ zbuilder:
   java_home: /usr/lpp/java/java21/current_64
 ```
 
-### zConfig Configuration
+### zconfig Configuration
 
 Defines settings for z/OS configuration tooling.
 

--- a/docs/docs/reference/glossary.md
+++ b/docs/docs/reference/glossary.md
@@ -37,6 +37,7 @@ This glossary defines common terms and technologies used throughout the Bank of 
 | **Workflow** | A defined development process used to build, deploy, test, and validate application changes. Bank of Z supports VS Code and GRUB workflows. |
 | **zBuilder** | A build framework used with DBB to automate compilation, linking, and build orchestration for z/OS applications. |
 | **ZCodeScan** | A static analysis tool used to analyze source code quality and identify potential issues. |
+| **zconfig** | z/OS Middleware Configuration Tool is a command-line tool to configure and create artifacts for CICS® Transaction Server for z/OS (CICS TS), Db2® for z/OS (Db2), Information Management System (IMS), and z/OS Connect introducing configuration as code to z/OS middleware.
 | **z/OS Connect** | An API framework that enables REST-based access to z/OS applications and services. In Bank of Z, it provides the interface between the web application and the CICS and IMS transaction environments. |
 | **ZOAU** | IBM Z Open Automation Utilities. A collection of utilities and APIs used to automate z/OS administration and development tasks. |
 | **Zowe CLI** | A command-line interface used to interact with z/OS systems, services, datasets, USS files, and development workflows. |


### PR DESCRIPTION
Uses the correct capitalization for zconfig
Adds the full name for zconfig to the pre-reqs
Adds a glossary entry for zconfig using the description from the zconfig docs