### PR TITLE
Docs footer copyright

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -655,7 +655,7 @@
     </div><!-- page-layout -->
 
     <footer class="footer">
-        <p>&copy; {{ 'now' | date: "%Y" }} {{ site.title }}. All rights reserved.</p>
+        <p>&copy; {{ 'now' | date: "%Y" }} IBM Corporation. All rights reserved.</p>
         <p>{{ site.description }}</p>
     </footer>
     


### PR DESCRIPTION
Docs template defaults to the site title - changed it to IBM Corp 