### PR TITLE
Add default user build workflow config and zapp profile

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,14 @@
 {
   "grub.buildCommand": "./.setup/pipeline-common.sh",
   "grub.serverRoot": "/usr/local/sandboxes/bank-of-z",
-  "java.compile.nullAnalysis.mode": "disabled"
+  "java.compile.nullAnalysis.mode": "disabled",
+  "zopeneditor.userbuild.userSettings": {
+        "dbbDefaultZappProfile": "zBuilder-userbuild",
+        "dbbHlq": "IBMUSER.BOZ.UB",
+        "dbbWorkspace": "/u/ibmuser/userBuild_boz",
+        "dbbApplication": "Bank-of-Z"
+    },
+    "zopeneditor.zowe": {
+        "defaultCliProfile": "onDemand.rse"
+    }
 }

--- a/dbb-app_ub.yaml
+++ b/dbb-app_ub.yaml
@@ -1,0 +1,390 @@
+---
+#
+# Licensed materials - Property of IBM
+# 5655-AC5 Copyright IBM Corp. 2024
+# All rights reserved
+# US Government users restricted rights  -  Use, duplication or
+# disclosure restricted by GSA ADP schedule contract with IBM Corp.
+#
+
+# ============================================================
+# DBB (Dependency Based Build) configuration file for the
+# Bank of Z z/OS native application.
+# Defines build tasks, source file patterns, compile options,
+# link-edit settings, and deployment types for COBOL and PL/I.
+# ============================================================
+
+version: 1.0.0
+
+application:
+  name: BANKZ
+
+  tasks:
+
+    - task: Start
+      variables:
+      # Configure the source directory for building
+      - name: sourceDirs
+        value:
+            - "Bank-of-Z/src/base"
+
+    - task: ScannerInit
+      variables:
+        - name: scanners
+          value:
+            - scanner: Dummy
+              extensions: yaml
+        - name: excludeFileList
+          value: [".*","**/.*","**.java","**.png","**.css","**.js","**.groovy","**.json","**.md","**/LoadData/**"]
+
+      # Variable overrides for the FullAnalysis task
+    - task: FullAnalysis
+      variables:
+        - name: continueOnScanFailure
+          value: true
+        - name: excludeFileList
+          value: [".*","**/.*","**.java","**.html","**.png","**.css","**.js","**.groovy","**.json","**.md","**/LoadData/**"]
+
+    # ----------------------------------------------------------
+    # ImpactAnalysis task
+    # Determines which programs need to be rebuilt when a source
+    # file changes, by tracing file dependencies (copybooks,
+    # BMS maps, static calls).
+    # ----------------------------------------------------------
+    - task: ImpactAnalysis
+      variables:
+        - name: continueOnScanFailure
+          value: true
+
+        - name: excludeFileList
+          value: [".*","**/.*","**.java","**.png","**.css","**.js","**.groovy","**.json","**.md","**/LoadData/**"]
+
+        
+        # Uncomment to log every file scanned during analysis:
+        #- name: printScannedItems
+        #  value: true
+
+        # Maps each language extension to the dependency file
+        # patterns it can reference. Used to build the impact
+        # graph when a shared file (e.g. a copybook) changes.
+        - name: impactQueryPatterns
+          value:
+            # COBOL program dependencies
+            - languageExt: cbl
+              dependencyPatterns:
+                - ${APP_DIR_NAME}/src/**/*.cpy   # COPY member (copybook)
+                - ${APP_DIR_NAME}/src/**/*.bms   # BMS map source
+                - ${APP_DIR_NAME}/src/**/.cbl    # Statically CALLed program
+
+            # Link-card dependencies: each .lnk file may reference
+            # one or more COBOL object modules to be link-edited.
+            - languageExt: lnk
+              dependencyPatterns:
+                - ${APP_DIR_NAME}/src/**/*.cbl   # COBOL object to include
+
+    # ----------------------------------------------------------
+    # Cobol task
+    # Compiles all COBOL sources found under src/base/**/cobol/
+    # and link-edits them into load modules.
+    # ----------------------------------------------------------
+    - task: Cobol
+      # Glob pattern selecting COBOL source files to compile
+      sources:
+        - "**/src/base/**/cobol/*.cbl"
+
+      variables:
+
+        # Automatically run the link-edit step after compilation
+        - name: doLinkEdit
+          value: true
+
+        # ----- Compiler parameters (default) -----
+        # Base option: LIB enables the COPY statement.
+        # Conditional suffixes are appended at build time:
+        #   CICS  - when the program uses EXEC CICS statements
+        #   SQL   - when the program uses embedded SQL
+        #   ADATA/EX - when an error prefix variable is set
+        #              (used by error-capture tooling)
+        #   TEST  - when the debug flag is set (enables debugger)
+        - name: compileParms
+          value: LIB
+          append:
+          - condition: ${IS_CICS}
+            value: CICS
+          - condition: ${IS_SQL}
+            value: SQL
+          - condition:
+              exists: errPrefix
+            value: ADATA,EX(ADX(ELAXMGUX))
+          - condition:
+              exists: debug
+              eval: ${debug}
+            value: TEST
+
+        # ----- Compiler parameters for IBTRAN (IMS Java bridge) -----
+        # IBTRAN is a special IMS program that bridges 31-bit COBOL to 64-bit Java.
+        # Critical parameters:
+        #   LP(32)           - 31-bit addressing mode
+        #   JAVAIOP(JAVA64)  - Enable 31-bit to 64-bit Java bridge via igzxjni2.x
+        #   DLL              - Create DLL-style load module
+        #   RENT             - Reentrant code required for IMS
+        #   PGMNAME(LONGMIXED) - Mixed-case entry points for Java interop
+        - name: compileParms
+          forFiles: "**/src/base/ims/cobol/IBTRAN.cbl"
+          value: XREF,PGMNAME(LONGMIXED),DLL,RENT,NOEXP,LP(32),JAVAIOP(JAVA64),LIB
+          append:
+          - condition:
+              exists: errPrefix
+            value: ADATA,EX(ADX(ELAXMGUX))
+          - condition:
+              exists: debug
+              eval: ${debug}
+            value: TEST
+
+        # ----- Link-edit parameters for IBTRAN -----
+        # DYNAM(DLL) produces a DLL-style load module required
+        # for the IMS Java integration; CASE(MIXED) preserves
+        # mixed-case external names.
+        - name: linkEditParms
+          forFiles: "**/src/base/ims/cobol/IBTRAN.cbl"
+          value: LIST,XREF,LET,DYNAM(DLL),CASE(MIXED)
+
+        # ----- Link-edit instream for IBTRAN -----
+        # Includes the IMS language interface (DFSLI000),
+        # the compiled object, and the 31-bit to 64-bit Java bridge libraries
+        # (igzxjni2.x and libjvm31.x) for JVM=3164 interoperability.
+        - name: linkEditStream
+          forFiles: "**/src/base/ims/cobol/IBTRAN.cbl"
+          value: |2
+              INCLUDE  RESLIB(DFSLI000)
+              INCLUDE  SYSLIB(${MEMBER})
+              INCLUDE '${IGZXJNI2}'
+              INCLUDE '${JAVA_HOME}/lib/j9vm/libjvm31.x'
+              NAME     IBTRAN(R)
+
+        # ----- Link-edit instream for IMS batch programs -----
+        # These programs use the IMS DL/I call interface (CBLTDLI).
+        # ENTRY DLITCBL sets the standard IMS COBOL entry point so
+        # IMS can locate and invoke the program correctly.
+        - name: linkEditStream
+          forFiles:
+            - "**/src/base/ims/cobol/IBACSUM.cbl"
+            - "**/src/base/ims/cobol/IBGCUDAT.cbl"
+            - "**/src/base/ims/cobol/IBLOGIN1.cbl"
+            - "**/src/base/ims/cobol/IBLOGOUT.cbl"
+            - "**/src/base/ims/cobol/IBSCUDAT.cbl"
+            - "**/src/base/ims/cobol/LOADACCT.cbl"
+            - "**/src/base/ims/cobol/LOADCUSA.cbl"
+            - "**/src/base/ims/cobol/LOADCUST.cbl"
+            - "**/src/base/ims/cobol/LOADHIST.cbl"
+            - "**/src/base/ims/cobol/LOADTSTA.cbl"
+          value: |2
+              INCLUDE  RESLIB(CBLTDLI)
+              INCLUDE  SYSLIB(${MEMBER})
+              ENTRY    DLITCBL
+              NAME     ${MEMBER}(R)
+
+        # Search path for copybooks (.cpy) used by COBOL sources.
+        # Scanned recursively under src/base/ in a single-repo build.
+        - name: dependencySearchPath
+          value: search:${WORKSPACE}/?path=${APP_DIR_NAME}/src/base/**/*.cpy
+
+        # ----- Deployment type -----
+        # Controls which target library the load module is deployed to:
+        #   LOAD     - standard batch load library (default)
+        #   CICSLOAD - CICS program library
+        #   IMSLOAD  - IMS program library (for all programs under ims/cobol/)
+        - name: deployType
+          value: LOAD
+          select:
+            - condition: ${IS_CICS}
+              value: CICSLOAD
+
+        - name: deployType
+          forFiles: "**/src/base/ims/cobol/*.cbl"
+          value: IMSLOAD
+
+    # ----------------------------------------------------------
+    # PLI task
+    # Compiles all PL/I sources found under src/base/**/pli/
+    # and link-edits them. IMS mode is enabled for all PL/I
+    # programs in this application.
+    # ----------------------------------------------------------
+    - task: PLI
+      # Glob pattern selecting PL/I source files to compile
+      sources:
+        - "**/src/base/**/*.pli"
+
+      variables:
+
+        # Automatically run the link-edit step after compilation
+        - name: doLinkEdit
+          value: true
+
+        # Enable IMS-specific compiler and runtime options
+        # (e.g. DL/I call support, IMS PSB/DBD handling)
+        # Enable IMS ONLY for programs under ims/pli/
+        - name: isIMS
+          forFiles: "**/src/base/ims/pli/*.pli"
+          value: true
+
+        # ----- Link-edit instream for IBLOGIN (IMS PL/I program) -----
+        # CEESTART is the Language Environment entry point required
+        # for PL/I programs running under IMS.
+        # DFSLI000 provides the IMS language interface stub.
+        - name: linkEditStream
+          forFiles:
+            - "**/src/base/ims/pli/IBLOGIN.pli"
+          value: |2
+              INCLUDE  SYSLIB(${MEMBER})
+              INCLUDE RESLIB(DFSLI000)
+              ENTRY CEESTART
+              
+        # ----- Link-edit instream for batch DB2 PL/I programs -----
+        # Batch programs use CEESTART but don't need DFSLI000
+        # DB2 connection handled via DSN RUN in JCL
+        - name: linkEditStream
+          forFiles: "**/src/base/batch/pli/*.pli"
+          value: |2
+              INCLUDE  SYSLIB(${MEMBER})
+              ENTRY CEESTART
+              NAME ${MEMBER}(R)
+              
+        # ----- Deployment type -----
+        # Controls which target library the load module is deployed to:
+        #   IMSLOAD  - IMS program library (for all programs under ims/pli/)
+        - name: deployType
+          forFiles: "**/src/base/ims/pli/*.pli"
+          value: IMSLOAD
+          
+        # ----- Deployment type for batch programs -----
+        - name: deployType
+          forFiles: "**/src/base/batch/pli/*.pli"
+          value: LOAD
+          
+    - task: MetadataInit
+      variables:
+       - name: fileLocation # Location of file system metadata store.
+         value: ${SANDBOX_DIR}  # Default is the $HOME environment variable.
+
+    # ----------------------------------------------------------
+    # Custom Groovy tasks for frontend and configuration packaging
+    # Defined in: .setup/build/groovy/CustomTasks.yaml
+    # ----------------------------------------------------------
+    # VanillaFrontend task
+    # Packages the vanilla JavaScript/HTML frontend into a WAR file
+    # for deployment to z/OS Connect Liberty server.
+    # ----------------------------------------------------------
+    - task: VanillaFrontend
+      variables:
+        - name: shellEnvironment
+          value: "/usr/lpp/IBM/foz/v1r1/bash/bash/bin/bash"
+        - name: javaHome
+          value: "${JAVA_HOME}"
+        - name: vanillaFrontendPath
+          value: "src/frontend"
+        - name: vanillaWarName
+          value: "bank-frontend-vanilla.war"
+        - name: zosConnectHttpPort
+          value: "${ZOSCONNECT_HTTP_PORT}"
+   
+
+    # ----------------------------------------------------------
+    # ServerXmlPackager task
+    # Packages Liberty server.xml and cics.xml configuration files
+    # for z/OS Connect deployment. These files contain placeholders
+    # that will be replaced with environment-specific values during
+    # deployment.
+    # ----------------------------------------------------------
+    
+    - task: ServerXmlPackager
+      variables:
+        - name: shellEnvironment
+          value: "/usr/lpp/IBM/foz/v1r1/bash/bash/bin/bash"
+        - name: serverXmlPath
+          value: "src/api/src/main/liberty/config/server.xml"
+        - name: cicsXmlPath
+          value: "src/api/src/main/liberty/config/cics.xml"
+
+    # ----------------------------------------------------------
+    # ImsJavaBuilder task
+    # Compiles the IMS Java JMP project via Gradle and packages
+    # the resulting JAR with deployType=IMS-JAR so Wazi Deploy
+    # copies it to the IMS Java classpath directory on USS.
+    # ----------------------------------------------------------
+    - task: ImsJavaBuilder
+      variables:
+        # Path to the Gradle executable on z/OS USS (shared with zOSConnect)
+        - name: gradlePath
+          value: "${GRADLE_HOME}/bin/gradle"
+        # Shell used to invoke Gradle (same as zOSConnect)
+        - name: shellEnvironment
+          value: "/usr/lpp/IBM/foz/v1r1/bash/bash/bin/bash"
+        # Relative path (from repo root) to the Gradle project directory
+        - name: configSources
+          value: "src/base/ims/java"
+
+    - task: zOSConnect
+      variables:
+        - name: configSources
+          value:
+            - "**/src/main/api/openapi.yaml"
+        - name: gradleDebug
+          value: true
+        - name: gradlePath
+          value: "${GRADLE_HOME}/bin/gradle"
+        - name: shellEnvironment
+          value: "/usr/lpp/IBM/foz/v1r1/bash/bash/bin/bash"
+    # ----------------------------------------------------------
+    # Assembler task
+    # Handles IMS control block sources: PSBs (Program Specification
+    # Blocks) and DBDs (Database Descriptors). These are not compiled
+    # like application programs. They are assembled by the IMS ACBGEN
+    # utility and stored in dedicated load libraries.
+    # ----------------------------------------------------------
+    - task: Assembler
+
+      variables:
+
+        # ----- Deployment type -----
+        # Determines which target library the assembled output is
+        # deployed to after a successful build:
+        #
+        #   LOAD    - default; standard load library for regular
+        #             assembler modules (no IMS-specific handling)
+        #
+        #   PSBLOAD - IMS PSB library; a PSB defines the set of
+        #             databases (DBDs) a program is allowed to access
+        #             and the sensitive segments within each DB.
+        #             Every IMS application program references exactly
+        #             one PSB at schedule time.
+        #
+        #   DBDLOAD - IMS DBD library; a DBD describes the physical
+        #             structure of an IMS database: segment types,
+        #             field layouts, and access methods (HDAM, HIDAM).
+        #             DBDs are the counterpart to PSBs - PSBs reference
+        #             DBDs to express what a program can see.
+        - name: deployType
+          forFiles: "**/src/base/ims/PSB/*.asm"
+          value: PSBLOAD
+
+        - name: deployType
+          forFiles: "**/src/base/ims/DBD/*.asm"
+          value: DBDLOAD
+
+        # Assembler parms
+        - name: assemblerParms
+          value: OBJECT,NODECK
+          append:
+          - condition: 
+              exists: errPrefix
+            value: ADATA,EX(ADX(ELAXHASM))
+          - condition: 
+              exists: debug
+              notExits: errPrefix
+              eval: ${debug}
+            value: ADATA
+
+        # Link edit parms
+        - name: linkEditParms
+          value: XREF,LIST

--- a/zapp.yaml
+++ b/zapp.yaml
@@ -7,6 +7,7 @@ description: >-
   details:
   https://ibm.github.io/zopeneditor-about/Docs/setting_propertygroup.html
 author: IBM Z Open Editor
+
 propertyGroups:
   - name: search-all
     libraries:
@@ -34,3 +35,21 @@ profiles:
         - type: local
           locations:
             - "zcodescan/zcodescan-rules.yaml"
+
+  - name: zBuilder-userbuild
+    type: dbb
+    settings:
+      command: "$DBB_HOME/bin/dbb build"
+      lifecycle: user
+      lifecycleArgs:
+        - "--hlq ${dbbHlq}"
+        - "--config ${dbbWorkspace}/${dbbApplication}/dbb-app_ub.yaml"
+        - "--errPrefix ${errPrefix}" # Requires advanced capabilities
+        - "--verbose"
+      additionalDependencies:
+        - "dbb-app.yaml"
+        - "dbb-app_ub.yaml"
+      logFilePatterns:
+        - "*.log" # Fetch build logs
+        - "*.json" # Fetch Runtime.json and BuildReport.json
+        - "*.html" # Fetch BuildReport.html


### PR DESCRIPTION
This is adding the necessary configurations to drive the IDZ on VSCode / Z Open Editor User build workflow - 
https://ibm.github.io/zopeneditor-about/Docs/advanced_user_build.html

It implements a workaround for zBuilder with a reported defect in the Start task configuration. Once the DBB defect is resolve, the additional file dbb-app_ub.yaml becomes obsolete.