### PR TITLE
fix: correct ABND-TIME seconds field in STRING statements (#205)

### DIFF
--- a/src/base/cics/cobol/BNK1CAC.cbl
+++ b/src/base/cics/cobol/BNK1CAC.cbl
@@ -286,7 +286,7 @@
                        ':' DELIMITED BY SIZE,
                        WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                        ':' DELIMITED BY SIZE,
-                       WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                       WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                        INTO ABND-TIME
                 END-STRING
 
@@ -393,7 +393,7 @@
                      ':' DELIMITED BY SIZE,
                      WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                      ':' DELIMITED BY SIZE,
-                     WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                     WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                      INTO ABND-TIME
               END-STRING
 
@@ -811,7 +811,7 @@
                        ':' DELIMITED BY SIZE,
                        WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                        ':' DELIMITED BY SIZE,
-                       WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                       WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                        INTO ABND-TIME
               END-STRING
 
@@ -1004,7 +1004,7 @@
                        ':' DELIMITED BY SIZE,
                         WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                         ':' DELIMITED BY SIZE,
-                        WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                        WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                         INTO ABND-TIME
                  END-STRING
 
@@ -1080,7 +1080,7 @@
                         ':' DELIMITED BY SIZE,
                         WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                         ':' DELIMITED BY SIZE,
-                        WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                        WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                         INTO ABND-TIME
                  END-STRING
 
@@ -1158,7 +1158,7 @@
                         ':' DELIMITED BY SIZE,
                         WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                         ':' DELIMITED BY SIZE,
-                        WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                        WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                         INTO ABND-TIME
                  END-STRING
 
@@ -1236,7 +1236,7 @@
                      ':' DELIMITED BY SIZE,
                      WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                      ':' DELIMITED BY SIZE,
-                     WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                     WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                      INTO ABND-TIME
               END-STRING
 

--- a/src/base/cics/cobol/BNK1CCA.cbl
+++ b/src/base/cics/cobol/BNK1CCA.cbl
@@ -280,7 +280,7 @@
                     ':' DELIMITED BY SIZE,
                      WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                      ':' DELIMITED BY SIZE,
-                     WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                     WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                      INTO ABND-TIME
               END-STRING
 
@@ -389,7 +389,7 @@
                      ':' DELIMITED BY SIZE,
                       WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                       ':' DELIMITED BY SIZE,
-                      WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                      WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                       INTO ABND-TIME
                END-STRING
 
@@ -490,7 +490,7 @@
                      ':' DELIMITED BY SIZE,
                              WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                       ':' DELIMITED BY SIZE,
-                      WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                      WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                       INTO ABND-TIME
               END-STRING
 
@@ -678,7 +678,7 @@
                        ':' DELIMITED BY SIZE,
                         WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                         ':' DELIMITED BY SIZE,
-                        WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                        WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                         INTO ABND-TIME
                  END-STRING
 
@@ -754,7 +754,7 @@
                        ':' DELIMITED BY SIZE,
                         WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                         ':' DELIMITED BY SIZE,
-                        WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                        WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                         INTO ABND-TIME
                  END-STRING
 
@@ -833,7 +833,7 @@
                        ':' DELIMITED BY SIZE,
                         WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                         ':' DELIMITED BY SIZE,
-                        WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                        WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                         INTO ABND-TIME
                  END-STRING
 
@@ -912,7 +912,7 @@
                     ':' DELIMITED BY SIZE,
                      WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                      ':' DELIMITED BY SIZE,
-                     WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                     WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                      INTO ABND-TIME
               END-STRING
 

--- a/src/base/cics/cobol/BNK1CCS.cbl
+++ b/src/base/cics/cobol/BNK1CCS.cbl
@@ -322,7 +322,7 @@
                     ':' DELIMITED BY SIZE,
                      WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                      ':' DELIMITED BY SIZE,
-                     WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                     WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                      INTO ABND-TIME
               END-STRING
 
@@ -453,7 +453,7 @@
                        ':' DELIMITED BY SIZE,
                         WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                         ':' DELIMITED BY SIZE,
-                        WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                        WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                         INTO ABND-TIME
                  END-STRING
 
@@ -550,7 +550,7 @@
                     ':' DELIMITED BY SIZE,
                      WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                      ':' DELIMITED BY SIZE,
-                     WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                     WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                      INTO ABND-TIME
               END-STRING
 
@@ -1028,7 +1028,7 @@
                     ':' DELIMITED BY SIZE,
                      WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                      ':' DELIMITED BY SIZE,
-                     WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                     WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                      INTO ABND-TIME
               END-STRING
 
@@ -1179,7 +1179,7 @@
                        ':' DELIMITED BY SIZE,
                         WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                         ':' DELIMITED BY SIZE,
-                        WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                        WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                         INTO ABND-TIME
                  END-STRING
 
@@ -1262,7 +1262,7 @@
                     ':' DELIMITED BY SIZE,
                      WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                      ':' DELIMITED BY SIZE,
-                     WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                     WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                      INTO ABND-TIME
               END-STRING
 
@@ -1341,7 +1341,7 @@
                        ':' DELIMITED BY SIZE,
                         WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                         ':' DELIMITED BY SIZE,
-                        WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                        WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                         INTO ABND-TIME
                  END-STRING
 
@@ -1420,7 +1420,7 @@
                        ':' DELIMITED BY SIZE,
                         WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                         ':' DELIMITED BY SIZE,
-                        WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                        WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                         INTO ABND-TIME
                  END-STRING
 
@@ -1499,7 +1499,7 @@
                        ':' DELIMITED BY SIZE,
                         WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                         ':' DELIMITED BY SIZE,
-                        WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                        WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                         INTO ABND-TIME
                  END-STRING
 
@@ -1579,7 +1579,7 @@
                     ':' DELIMITED BY SIZE,
                      WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                      ':' DELIMITED BY SIZE,
-                     WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                     WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                      INTO ABND-TIME
               END-STRING
 

--- a/src/base/cics/cobol/BNK1CRA.cbl
+++ b/src/base/cics/cobol/BNK1CRA.cbl
@@ -294,7 +294,7 @@
                     ':' DELIMITED BY SIZE,
                      WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                      ':' DELIMITED BY SIZE,
-                     WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                     WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                      INTO ABND-TIME
               END-STRING
 
@@ -401,7 +401,7 @@
                     ':' DELIMITED BY SIZE,
                      WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                      ':' DELIMITED BY SIZE,
-                     WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                     WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                      INTO ABND-TIME
               END-STRING
 
@@ -542,7 +542,7 @@
                     ':' DELIMITED BY SIZE,
                      WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                      ':' DELIMITED BY SIZE,
-                     WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                     WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                      INTO ABND-TIME
               END-STRING
 
@@ -681,7 +681,7 @@
                        ':' DELIMITED BY SIZE,
                         WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                         ':' DELIMITED BY SIZE,
-                        WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                        WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                         INTO ABND-TIME
                  END-STRING
 
@@ -756,7 +756,7 @@
                        ':' DELIMITED BY SIZE,
                         WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                         ':' DELIMITED BY SIZE,
-                        WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                        WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                         INTO ABND-TIME
                  END-STRING
 
@@ -832,7 +832,7 @@
                        ':' DELIMITED BY SIZE,
                         WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                         ':' DELIMITED BY SIZE,
-                        WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                        WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                         INTO ABND-TIME
                  END-STRING
 
@@ -910,7 +910,7 @@
                     ':' DELIMITED BY SIZE,
                      WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                      ':' DELIMITED BY SIZE,
-                     WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                     WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                      INTO ABND-TIME
               END-STRING
 

--- a/src/base/cics/cobol/BNK1DAC.cbl
+++ b/src/base/cics/cobol/BNK1DAC.cbl
@@ -327,7 +327,7 @@
                     ':' DELIMITED BY SIZE,
                      WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                      ':' DELIMITED BY SIZE,
-                     WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                     WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                      INTO ABND-TIME
               END-STRING
 
@@ -458,7 +458,7 @@
                     ':' DELIMITED BY SIZE,
                      WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                      ':' DELIMITED BY SIZE,
-                     WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                     WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                      INTO ABND-TIME
               END-STRING
 
@@ -585,7 +585,7 @@
                     ':' DELIMITED BY SIZE,
                      WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                      ':' DELIMITED BY SIZE,
-                     WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                     WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                      INTO ABND-TIME
               END-STRING
 
@@ -860,7 +860,7 @@
                        ':' DELIMITED BY SIZE,
                         WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                         ':' DELIMITED BY SIZE,
-                        WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                        WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                         INTO ABND-TIME
                  END-STRING
 
@@ -940,7 +940,7 @@
                        ':' DELIMITED BY SIZE,
                         WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                         ':' DELIMITED BY SIZE,
-                        WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                        WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                         INTO ABND-TIME
                  END-STRING
 
@@ -1016,7 +1016,7 @@
                        ':' DELIMITED BY SIZE,
                         WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                         ':' DELIMITED BY SIZE,
-                        WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                        WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                         INTO ABND-TIME
                  END-STRING
 
@@ -1095,7 +1095,7 @@
                     ':' DELIMITED BY SIZE,
                      WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                      ':' DELIMITED BY SIZE,
-                     WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                     WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                      INTO ABND-TIME
               END-STRING
 

--- a/src/base/cics/cobol/BNK1DCS.cbl
+++ b/src/base/cics/cobol/BNK1DCS.cbl
@@ -395,7 +395,7 @@
                      ':' DELIMITED BY SIZE,
                      WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                      ':' DELIMITED BY SIZE,
-                     WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                     WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                  INTO ABND-TIME
               END-STRING
 
@@ -592,7 +592,7 @@
                         ':' DELIMITED BY SIZE,
                         WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                         ':' DELIMITED BY SIZE,
-                        WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                        WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                     INTO ABND-TIME
                  END-STRING
 
@@ -667,7 +667,7 @@
                      ':' DELIMITED BY SIZE,
                      WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                      ':' DELIMITED BY SIZE,
-                     WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                     WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                  INTO ABND-TIME
               END-STRING
 
@@ -897,7 +897,7 @@
                      ':' DELIMITED BY SIZE,
                      WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                      ':' DELIMITED BY SIZE,
-                     WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                     WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                  INTO ABND-TIME
               END-STRING
 
@@ -1042,7 +1042,7 @@
                      ':' DELIMITED BY SIZE,
                      WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                      ':' DELIMITED BY SIZE,
-                     WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                     WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                  INTO ABND-TIME
               END-STRING
 
@@ -1247,7 +1247,7 @@
                      ':' DELIMITED BY SIZE,
                      WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                      ':' DELIMITED BY SIZE,
-                     WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                     WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                  INTO ABND-TIME
               END-STRING
 
@@ -1542,7 +1542,7 @@
                         ':' DELIMITED BY SIZE,
                         WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                         ':' DELIMITED BY SIZE,
-                        WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                        WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                     INTO ABND-TIME
                  END-STRING
 
@@ -1620,7 +1620,7 @@
                         ':' DELIMITED BY SIZE,
                         WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                         ':' DELIMITED BY SIZE,
-                        WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                        WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                     INTO ABND-TIME
                  END-STRING
 
@@ -1699,7 +1699,7 @@
                         ':' DELIMITED BY SIZE,
                         WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                         ':' DELIMITED BY SIZE,
-                        WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                        WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                     INTO ABND-TIME
                  END-STRING
 
@@ -1801,7 +1801,7 @@
                         ':' DELIMITED BY SIZE,
                         WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                         ':' DELIMITED BY SIZE,
-                        WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                        WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                     INTO ABND-TIME
                  END-STRING
 
@@ -1888,7 +1888,7 @@
                      ':' DELIMITED BY SIZE,
                      WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                      ':' DELIMITED BY SIZE,
-                     WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                     WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                  INTO ABND-TIME
               END-STRING
 
@@ -1969,7 +1969,7 @@
                      ':' DELIMITED BY SIZE,
                      WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                      ':' DELIMITED BY SIZE,
-                     WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                     WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                  INTO ABND-TIME
               END-STRING
 

--- a/src/base/cics/cobol/BNK1TFN.cbl
+++ b/src/base/cics/cobol/BNK1TFN.cbl
@@ -278,7 +278,7 @@
                     ':' DELIMITED BY SIZE,
                      WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                      ':' DELIMITED BY SIZE,
-                     WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                     WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                      INTO ABND-TIME
               END-STRING
 
@@ -387,7 +387,7 @@
                     ':' DELIMITED BY SIZE,
                      WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                      ':' DELIMITED BY SIZE,
-                     WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                     WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                      INTO ABND-TIME
               END-STRING
 
@@ -527,7 +527,7 @@
                     ':' DELIMITED BY SIZE,
                      WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                      ':' DELIMITED BY SIZE,
-                     WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                     WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                      INTO ABND-TIME
               END-STRING
 
@@ -704,7 +704,7 @@
                        ':' DELIMITED BY SIZE,
                         WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                         ':' DELIMITED BY SIZE,
-                        WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                        WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                         INTO ABND-TIME
                  END-STRING
 
@@ -779,7 +779,7 @@
                        ':' DELIMITED BY SIZE,
                         WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                         ':' DELIMITED BY SIZE,
-                        WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                        WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                         INTO ABND-TIME
                  END-STRING
 
@@ -855,7 +855,7 @@
                        ':' DELIMITED BY SIZE,
                         WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                         ':' DELIMITED BY SIZE,
-                        WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                        WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                         INTO ABND-TIME
                  END-STRING
 
@@ -933,7 +933,7 @@
                     ':' DELIMITED BY SIZE,
                      WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                      ':' DELIMITED BY SIZE,
-                     WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                     WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                      INTO ABND-TIME
               END-STRING
 

--- a/src/base/cics/cobol/BNK1UAC.cbl
+++ b/src/base/cics/cobol/BNK1UAC.cbl
@@ -326,7 +326,7 @@
                     ':' DELIMITED BY SIZE,
                      WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                      ':' DELIMITED BY SIZE,
-                     WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                     WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                      INTO ABND-TIME
               END-STRING
 
@@ -450,7 +450,7 @@
                     ':' DELIMITED BY SIZE,
                      WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                      ':' DELIMITED BY SIZE,
-                     WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                     WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                      INTO ABND-TIME
               END-STRING
 
@@ -798,7 +798,7 @@
                     ':' DELIMITED BY SIZE,
                      WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                      ':' DELIMITED BY SIZE,
-                     WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                     WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                      INTO ABND-TIME
               END-STRING
 
@@ -985,7 +985,7 @@
                     ':' DELIMITED BY SIZE,
                      WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                      ':' DELIMITED BY SIZE,
-                     WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                     WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                      INTO ABND-TIME
               END-STRING
 
@@ -1107,7 +1107,7 @@
                        ':' DELIMITED BY SIZE,
                         WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                         ':' DELIMITED BY SIZE,
-                        WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                        WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                         INTO ABND-TIME
                  END-STRING
 
@@ -1184,7 +1184,7 @@
                        ':' DELIMITED BY SIZE,
                         WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                         ':' DELIMITED BY SIZE,
-                        WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                        WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                         INTO ABND-TIME
                  END-STRING
 
@@ -1261,7 +1261,7 @@
                        ':' DELIMITED BY SIZE,
                         WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                         ':' DELIMITED BY SIZE,
-                        WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                        WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                         INTO ABND-TIME
                  END-STRING
 
@@ -1340,7 +1340,7 @@
                      ':' DELIMITED BY SIZE,
                      WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                      ':' DELIMITED BY SIZE,
-                     WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                     WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                      INTO ABND-TIME
               END-STRING
 

--- a/src/base/cics/cobol/BNKMENU.cbl
+++ b/src/base/cics/cobol/BNKMENU.cbl
@@ -201,7 +201,7 @@
                     ':' DELIMITED BY SIZE,
                      WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                      ':' DELIMITED BY SIZE,
-                     WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                     WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                      INTO ABND-TIME
               END-STRING
 
@@ -313,7 +313,7 @@
                        ':' DELIMITED BY SIZE,
                         WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                         ':' DELIMITED BY SIZE,
-                        WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                        WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                         INTO ABND-TIME
                  END-STRING
 
@@ -417,7 +417,7 @@
                        ':' DELIMITED BY SIZE,
                         WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                       ':' DELIMITED BY SIZE,
-                       WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                       WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                        INTO ABND-TIME
                  END-STRING
 
@@ -489,7 +489,7 @@
                        ':' DELIMITED BY SIZE,
                         WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                         ':' DELIMITED BY SIZE,
-                        WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                        WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                         INTO ABND-TIME
                  END-STRING
 
@@ -562,7 +562,7 @@
                        ':' DELIMITED BY SIZE,
                         WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                         ':' DELIMITED BY SIZE,
-                        WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                        WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                         INTO ABND-TIME
                  END-STRING
 
@@ -635,7 +635,7 @@
                        ':' DELIMITED BY SIZE,
                         WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                         ':' DELIMITED BY SIZE,
-                        WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                        WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                         INTO ABND-TIME
                  END-STRING
 
@@ -708,7 +708,7 @@
                        ':' DELIMITED BY SIZE,
                         WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                         ':' DELIMITED BY SIZE,
-                        WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                        WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                         INTO ABND-TIME
                  END-STRING
 
@@ -781,7 +781,7 @@
                        ':' DELIMITED BY SIZE,
                         WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                         ':' DELIMITED BY SIZE,
-                        WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                        WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                         INTO ABND-TIME
                  END-STRING
 
@@ -854,7 +854,7 @@
                        ':' DELIMITED BY SIZE,
                         WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                         ':' DELIMITED BY SIZE,
-                        WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                        WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                         INTO ABND-TIME
                  END-STRING
 
@@ -928,7 +928,7 @@
                        ':' DELIMITED BY SIZE,
                         WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                         ':' DELIMITED BY SIZE,
-                        WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                        WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                         INTO ABND-TIME
                  END-STRING
 
@@ -1011,7 +1011,7 @@
                        ':' DELIMITED BY SIZE,
                         WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                         ':' DELIMITED BY SIZE,
-                        WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                        WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                         INTO ABND-TIME
                  END-STRING
 
@@ -1087,7 +1087,7 @@
                        ':' DELIMITED BY SIZE,
                         WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                         ':' DELIMITED BY SIZE,
-                        WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                        WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                         INTO ABND-TIME
                  END-STRING
 
@@ -1165,7 +1165,7 @@
                        ':' DELIMITED BY SIZE,
                         WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                         ':' DELIMITED BY SIZE,
-                        WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                        WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                         INTO ABND-TIME
                  END-STRING
 
@@ -1244,7 +1244,7 @@
                      ':' DELIMITED BY SIZE,
                      WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                      ':' DELIMITED BY SIZE,
-                     WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                     WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                      INTO ABND-TIME
               END-STRING
 

--- a/src/base/cics/cobol/CRDTAGY1.cbl
+++ b/src/base/cics/cobol/CRDTAGY1.cbl
@@ -142,7 +142,7 @@
                       ':' DELIMITED BY SIZE,
                        WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                        ':' DELIMITED BY SIZE,
-                       WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                       WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                        INTO ABND-TIME
               END-STRING
 

--- a/src/base/cics/cobol/CRDTAGY2.cbl
+++ b/src/base/cics/cobol/CRDTAGY2.cbl
@@ -141,7 +141,7 @@
                       ':' DELIMITED BY SIZE,
                        WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                        ':' DELIMITED BY SIZE,
-                       WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                       WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                        INTO ABND-TIME
               END-STRING
 

--- a/src/base/cics/cobol/CRDTAGY3.cbl
+++ b/src/base/cics/cobol/CRDTAGY3.cbl
@@ -141,7 +141,7 @@
                       ':' DELIMITED BY SIZE,
                        WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                        ':' DELIMITED BY SIZE,
-                       WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                       WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                        INTO ABND-TIME
               END-STRING
 

--- a/src/base/cics/cobol/CRDTAGY4.cbl
+++ b/src/base/cics/cobol/CRDTAGY4.cbl
@@ -142,7 +142,7 @@
                       ':' DELIMITED BY SIZE,
                        WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                        ':' DELIMITED BY SIZE,
-                       WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                       WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                        INTO ABND-TIME
               END-STRING
 

--- a/src/base/cics/cobol/CRDTAGY5.cbl
+++ b/src/base/cics/cobol/CRDTAGY5.cbl
@@ -141,7 +141,7 @@
                       ':' DELIMITED BY SIZE,
                        WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                        ':' DELIMITED BY SIZE,
-                       WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                       WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                        INTO ABND-TIME
               END-STRING
 

--- a/src/base/cics/cobol/CREACC.cbl
+++ b/src/base/cics/cobol/CREACC.cbl
@@ -537,7 +537,7 @@
                      ':' DELIMITED BY SIZE,
                      WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                      ':' DELIMITED BY SIZE,
-                     WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                     WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                  INTO ABND-TIME
               END-STRING
 
@@ -628,7 +628,7 @@
                         ':' DELIMITED BY SIZE,
                         WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                         ':' DELIMITED BY SIZE,
-                        WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                        WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                     INTO ABND-TIME
                  END-STRING
 
@@ -726,7 +726,7 @@
                      ':' DELIMITED BY SIZE,
                      WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                      ':' DELIMITED BY SIZE,
-                     WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                     WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                  INTO ABND-TIME
               END-STRING
 
@@ -812,7 +812,7 @@
                         ':' DELIMITED BY SIZE,
                         WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                         ':' DELIMITED BY SIZE,
-                        WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                        WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                     INTO ABND-TIME
                  END-STRING
 
@@ -1125,7 +1125,7 @@
                      ':' DELIMITED BY SIZE,
                      WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                      ':' DELIMITED BY SIZE,
-                     WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                     WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                  INTO ABND-TIME
               END-STRING
 

--- a/src/base/cics/cobol/CRECUST.cbl
+++ b/src/base/cics/cobol/CRECUST.cbl
@@ -1413,7 +1413,7 @@
                      ':' DELIMITED BY SIZE,
                      WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                      ':' DELIMITED BY SIZE,
-                     WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                     WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                  INTO ABND-TIME
               END-STRING
 

--- a/src/base/cics/cobol/DBCRFUN.cbl
+++ b/src/base/cics/cobol/DBCRFUN.cbl
@@ -600,7 +600,7 @@
                        ':' DELIMITED BY SIZE,
                         WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                         ':' DELIMITED BY SIZE,
-                        WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                        WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                         INTO ABND-TIME
                  END-STRING
 
@@ -787,7 +787,7 @@
                        ':' DELIMITED BY SIZE,
                         WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                         ':' DELIMITED BY SIZE,
-                        WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                        WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                         INTO ABND-TIME
                     END-STRING
 

--- a/src/base/cics/cobol/DELACC.cbl
+++ b/src/base/cics/cobol/DELACC.cbl
@@ -306,7 +306,7 @@
                      ':' DELIMITED BY SIZE,
                      WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                      ':' DELIMITED BY SIZE,
-                     WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                     WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                      INTO ABND-TIME
               END-STRING
 
@@ -576,7 +576,7 @@
                     ':' DELIMITED BY SIZE,
                      WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                      ':' DELIMITED BY SIZE,
-                     WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                     WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                      INTO ABND-TIME
               END-STRING
 

--- a/src/base/cics/cobol/DELCUS.cbl
+++ b/src/base/cics/cobol/DELCUS.cbl
@@ -513,7 +513,7 @@
                      ':' DELIMITED BY SIZE,
                      WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                      ':' DELIMITED BY SIZE,
-                     WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                     WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                  INTO ABND-TIME
               END-STRING
 
@@ -669,7 +669,7 @@
                      ':' DELIMITED BY SIZE,
                      WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                      ':' DELIMITED BY SIZE,
-                     WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                     WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                  INTO ABND-TIME
               END-STRING
 
@@ -832,7 +832,7 @@
                      ':' DELIMITED BY SIZE,
                      WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                      ':' DELIMITED BY SIZE,
-                     WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                     WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                  INTO ABND-TIME
               END-STRING
 

--- a/src/base/cics/cobol/INQACC.cbl
+++ b/src/base/cics/cobol/INQACC.cbl
@@ -297,7 +297,7 @@
                     ':' DELIMITED BY SIZE,
                      WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                      ':' DELIMITED BY SIZE,
-                     WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                     WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                      INTO ABND-TIME
               END-STRING
 
@@ -377,7 +377,7 @@
                     ':' DELIMITED BY SIZE,
                      WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                      ':' DELIMITED BY SIZE,
-                     WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                     WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                      INTO ABND-TIME
               END-STRING
 
@@ -492,7 +492,7 @@
                     ':' DELIMITED BY SIZE,
                      WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                      ':' DELIMITED BY SIZE,
-                     WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                     WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                      INTO ABND-TIME
               END-STRING
 
@@ -711,7 +711,7 @@
                        ':' DELIMITED BY SIZE,
                         WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                         ':' DELIMITED BY SIZE,
-                        WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                        WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                         INTO ABND-TIME
                    END-STRING
 
@@ -786,7 +786,7 @@
                      ':' DELIMITED BY SIZE,
                      WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                      ':' DELIMITED BY SIZE,
-                     WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                     WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                      INTO ABND-TIME
               END-STRING
 
@@ -899,7 +899,7 @@
                    ':' DELIMITED BY SIZE,
                     WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                     ':' DELIMITED BY SIZE,
-                    WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                    WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                      INTO ABND-TIME
               END-STRING
 

--- a/src/base/cics/cobol/INQACCCU.cbl
+++ b/src/base/cics/cobol/INQACCCU.cbl
@@ -294,7 +294,7 @@
                        ':' DELIMITED BY SIZE,
                         WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                         ':' DELIMITED BY SIZE,
-                        WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                        WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                         INTO ABND-TIME
                  END-STRING
 
@@ -397,7 +397,7 @@
                        ':' DELIMITED BY SIZE,
                         WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                         ':' DELIMITED BY SIZE,
-                        WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                        WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                         INTO ABND-TIME
                  END-STRING
 
@@ -536,7 +536,7 @@
                        ':' DELIMITED BY SIZE,
                        WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                        ':' DELIMITED BY SIZE,
-                       WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                       WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                        INTO ABND-TIME
                     END-STRING
 
@@ -766,7 +766,7 @@
                           ':' DELIMITED BY SIZE,
                            WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                           ':' DELIMITED BY SIZE,
-                          WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                          WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                           INTO ABND-TIME
                     END-STRING
 

--- a/src/base/cics/cobol/INQCUST.cbl
+++ b/src/base/cics/cobol/INQCUST.cbl
@@ -482,7 +482,7 @@
                     ':' DELIMITED BY SIZE,
                      WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                      ':' DELIMITED BY SIZE,
-                     WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                     WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                      INTO ABND-TIME
               END-STRING
 
@@ -601,7 +601,7 @@
                        ':' DELIMITED BY SIZE,
                         WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                         ':' DELIMITED BY SIZE,
-                        WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                        WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                         INTO ABND-TIME
                  END-STRING
 

--- a/src/base/cics/cobol/XFRFUN.cbl
+++ b/src/base/cics/cobol/XFRFUN.cbl
@@ -340,7 +340,7 @@
                     ':' DELIMITED BY SIZE,
                     WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                     ':' DELIMITED BY SIZE,
-                    WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                    WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                     INTO ABND-TIME
               END-STRING
 
@@ -436,7 +436,7 @@
                              ':' DELIMITED BY SIZE,
                              WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                              ':' DELIMITED BY SIZE,
-                             WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                             WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                              INTO ABND-TIME
                           END-STRING
 
@@ -549,7 +549,7 @@
                         ':' DELIMITED BY SIZE,
                         WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                         ':' DELIMITED BY SIZE,
-                        WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                        WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                         INTO ABND-TIME
                     END-STRING
 
@@ -640,7 +640,7 @@
                           ':' DELIMITED BY SIZE,
                           WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                           ':' DELIMITED BY SIZE,
-                          WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                          WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                           INTO ABND-TIME
                        END-STRING
 
@@ -710,7 +710,7 @@
                              ':' DELIMITED BY SIZE,
                               WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                               ':' DELIMITED BY SIZE,
-                              WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                              WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                               INTO ABND-TIME
                           END-STRING
 
@@ -789,7 +789,7 @@
                        ':' DELIMITED BY SIZE,
                        WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                        ':' DELIMITED BY SIZE,
-                       WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                       WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                        INTO ABND-TIME
                     END-STRING
 
@@ -855,7 +855,7 @@
                           ':' DELIMITED BY SIZE,
                           WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                           ':' DELIMITED BY SIZE,
-                          WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                          WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                           INTO ABND-TIME
                        END-STRING
 
@@ -1139,7 +1139,7 @@
                           ':' DELIMITED BY SIZE,
                           WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                           ':' DELIMITED BY SIZE,
-                          WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                          WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                           INTO ABND-TIME
                     END-STRING
 
@@ -1236,7 +1236,7 @@
                                 ':' DELIMITED BY SIZE,
                                 WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                                 ':' DELIMITED BY SIZE,
-                                WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                                WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                                 INTO ABND-TIME
                              END-STRING
 
@@ -1314,7 +1314,7 @@
                         ':' DELIMITED BY SIZE,
                         WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                         ':' DELIMITED BY SIZE,
-                        WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                        WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                         INTO ABND-TIME
                     END-STRING
 
@@ -1433,7 +1433,7 @@
                              ':' DELIMITED BY SIZE,
                              WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                              ':' DELIMITED BY SIZE,
-                             WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                             WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                              INTO ABND-TIME
                           END-STRING
 
@@ -1514,7 +1514,7 @@
                         ':' DELIMITED BY SIZE,
                         WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                         ':' DELIMITED BY SIZE,
-                        WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                        WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                         INTO ABND-TIME
               END-STRING
 
@@ -1679,7 +1679,7 @@
                      ':' DELIMITED BY SIZE,
                      WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                      ':' DELIMITED BY SIZE,
-                     WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                     WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                      INTO ABND-TIME
               END-STRING
 
@@ -1816,7 +1816,7 @@
                      ':' DELIMITED BY SIZE,
                      WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                      ':' DELIMITED BY SIZE,
-                     WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                     WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                      INTO ABND-TIME
               END-STRING
 
@@ -1989,7 +1989,7 @@
                        ':' DELIMITED BY SIZE,
                         WS-TIME-NOW-GRP-MM DELIMITED BY SIZE,
                         ':' DELIMITED BY SIZE,
-                        WS-TIME-NOW-GRP-MM DELIMITED BY SIZE
+                        WS-TIME-NOW-GRP-SS DELIMITED BY SIZE
                         INTO ABND-TIME
                     END-STRING
 


### PR DESCRIPTION
Fixes #205

## Summary

A copy-paste error caused `ABND-TIME` to display `HH:MM:MM` instead
of `HH:MM:SS` in 23 CICS programs (124 occurrences).

The last operand in the `STRING` statement building `ABND-TIME` used
`WS-TIME-NOW-GRP-MM` (minutes) instead of `WS-TIME-NOW-GRP-SS` (seconds).

## Change

Replace `WS-TIME-NOW-GRP-MM` with `WS-TIME-NOW-GRP-SS` as the final
operand in all affected `STRING ... INTO ABND-TIME` statements.

`INQTRAND` and `INQTRANL` already used `WS-TIME-NOW-GRP-SS` correctly
and were not modified.

## Verification

```bash
# Before fix
grep -rn "WS-TIME-NOW-GRP-MM DELIMITED BY SIZE$" src/base/cics/cobol/ | wc -l
# 124

# After fix
grep -rn "WS-TIME-NOW-GRP-MM DELIMITED BY SIZE$" src/base/cics/cobol/ | wc -l
# 0
```