### PR TITLE
Update zopeneditor.zowe.defaultCliProfile in settings.json to point to repo config prof

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,6 +9,6 @@
         "dbbApplication": "Bank-of-Z"
     },
     "zopeneditor.zowe": {
-        "defaultCliProfile": "onDemand.rse"
+        "defaultCliProfile": "bank-of-z.rse"
     }
 }


### PR DESCRIPTION
Update `zopeneditor.zowe.defaultCliProfile` in settings.json to point to repo config profile for rse connection.  the onDemand.rse profile was causing errors in IBM Z Open Editor since no profile of that name exists.  Suggesting to use the rse type profile included in the repo's Zowe team configuration `bank-of-z.rse`


Error seen with `main` branch while using IBM Z Open Editor
```
CRRZG5323W IBM Z Open Editor was not able to find a valid Zowe CLI profile to use. Review the following error 
message and try to fix the problem by checking if valid entries were defined for zopeneditor.zowe in your VS Code
 user settings: "Zowe Explorer Profiles Cache error: Could not find profile named: onDemand.rse."
```