### PR TITLE
Setup EQAPROF to support IMS debug

### DIFF
--- a/.setup/config/config.yaml
+++ b/.setup/config/config.yaml
@@ -170,6 +170,9 @@ debug:
   debug_hlq: "{{ global.debug_hlq }}"
   tcpip_hlq: "{{ global.tcpip_hlq }}"
   eqaprof_conf_dir: "{{ sandbox.path }}/debug"
+  eqaprof_keystore_file: "safkeyring://STCDBG/EQAPROF_Ring"
+  eqaprof_port: 8192
+  eqaprof_port_shutdown: 8105
 
 # z/OS Connect (API exposure only)
 # Hosts api.war at /api. Frontend WAR is deployed to the separate Frontend Liberty server.

--- a/.setup/config/config.yaml
+++ b/.setup/config/config.yaml
@@ -169,6 +169,7 @@ wazideploy:
 debug:
   debug_hlq: "{{ global.debug_hlq }}"
   tcpip_hlq: "{{ global.tcpip_hlq }}"
+  eqaprof_conf_dir: "{{ sandbox.path }}/debug"
 
 # z/OS Connect (API exposure only)
 # Hosts api.war at /api. Frontend WAR is deployed to the separate Frontend Liberty server.

--- a/.setup/config/setenv.sh
+++ b/.setup/config/setenv.sh
@@ -157,6 +157,7 @@ ZCONFIG_HOME="${ZCONFIG_HOME:-$(get_section_value 'zconfig' 'zconfig_home')}"
 # Debug
 DEBUG_HLQ=$(get_section_value 'debug' 'debug_hlq')
 DEBUG_TCPIP_HQL=$(get_section_value 'debug' 'tcpip_hlq')
+EQAPROF_CONF_DIR=$(get_section_value 'debug' 'eqaprof_conf_dir')
 
 # Db2
 DB2_HLQ="${DB2_HLQ:-$(get_section_value 'db2' 'db2_hlq')}"

--- a/.setup/debug_config/eqaprof.env.j2
+++ b/.setup/debug_config/eqaprof.env.j2
@@ -1,0 +1,476 @@
+# ====================================================================
+# Debug Profile Service configurations
+# ====================================================================
+# Changes
+#
+# APIVersion 1.2: 
+#  - Removed port_http & port_https
+#  - Added 'port' and 'SECURE' ("Y" for HTTPS, "N" for HTTP)
+# APIVersion 1.4: 
+#  - Added IMS ISO API configuration fields
+# APIVersion 1.6: 
+#  - Added AUTH API configuration fields
+# APIVersion 1.7: 
+# - Added Liberty configuration shutdown port field
+# APIVersion 2.1: 
+# - Added Liberty Swagger UI server URL override field
+# - Added keystorePassFile field
+# ====================================================================
+
+#---------------------------------------------------------------------
+# Define the path where Java is installed.
+#---------------------------------------------------------------------
+
+# Home directory of the 64-bit Java SDK
+# ** COMMONLY CUSTOMIZED **
+java_dir=/usr/lpp/java/java21/current_64/
+    
+#---------------------------------------------------------------------
+# Define the path where Liberty is installed.
+#---------------------------------------------------------------------
+
+# Home directory of IBM z/OS Liberty Embedded web server
+# ** COMMONLY CUSTOMIZED **
+liberty_dir=/usr/lpp/liberty_zos/current
+
+#---------------------------------------------------------------------
+# Liberty Generic Configurations - Port Settings
+#---------------------------------------------------------------------
+
+# Define the port number the server listens to for incoming requests
+# ** COMMONLY CUSTOMIZED **
+port="8192"
+
+# Define ephemeral port to stop the server or issue java dumps.
+# If it is not defined, then it is assigned dynamically by z/OS.
+# Input:
+#   - An integer from 1 to 65535 for a fixed port
+#   - Use -1 to disable the shutdown port
+# ** OPTIONAL **
+port_shutdown="8105"
+
+#---------------------------------------------------------------------
+# Liberty Generic Configurations - Enable/Disable Secure Communication
+#
+# You MUST define the SECURE environment variable with one of:
+#   "N"        - Non-secure HTTP
+#   "AT-TLS"   - Secure HTTPS via AT-TLS policy
+#   "Y"        - Secure HTTPS using a keystore
+#
+# If you set SECURE="Y", you MUST also define the following:
+#   - keystoreType     : One of PKCS12, JCERACFKS, or JCECCARACFKS
+#   - keystoreFile     : Path to the keystore file or keyring
+#   
+#   To provide the keystore password, you must choose 
+#   keystorePass or keystorePassFile:
+#
+#   - keystorePass     : The password used to access the keystore.
+#                        This value may be plain text or
+#                        in an encrypted format using Liberty's
+#                        securityUtility (e.g., {aes}...).
+#
+#   - keystorePassFile : The full path to a file containing the 
+#                        keystore password. The content of the file
+#                        should be the password only, either in plain
+#                        text or in encrypted format using Liberty's 
+#                        securityUtility (e.g., {aes}...).
+#
+#   - keystorePassEncryptionKeyFile (Optional):
+#                        The full path to a file containing the
+#                        encryption key used to encrypt the keystore
+#                        password with Liberty's securityUtility.
+#                        This is required only if a custom key was 
+#                        used during encryption. The same key must
+#                        be provided during runtime to enable
+#                        successful decryption. This overrides 
+#                        Liberty's default internal key.
+#
+# Note: When using RACF key rings, the password must be set to 
+#       "password", either in plain text or encrypted. This value is 
+#       required by Liberty but is not actually used because
+#       RACF key rings are not secured with passwords.
+#---------------------------------------------------------------------
+
+# For non-secured HTTP protocol
+#SECURE="N"
+        
+# For secured HTTPS protocol with an AT-TLS policy
+#SECURE="AT-TLS"
+
+# For secured HTTPS protocol with PKCS12, JCERACFKS, or JCECCARACFKS
+SECURE="Y"
+
+ # [Certificate scenario 1: PKCS12 keystore file]
+ # Type of certificate storage
+keystoreType="JCERACFKS"
+ # Pathname of the keystore file
+ # ** COMMONLY CUSTOMIZED **
+keystoreFile="safkeyring://STCDBG/EQAPROF_Ring"
+ # Password to access the server certificate from the keystore
+ # ** COMMONLY CUSTOMIZED **
+keystorePass="password"
+ # Password file to access the server certificate from the keystore
+ # ** COMMONLY CUSTOMIZED **
+#keystorePassFile=
+ # Encryption key file to decrypt the encrypted keystore password
+ # ** OPTIONAL **
+ #keystorePassEncryptionKeyFile="$EQAPROF_CFG_DIR/encryption.key"
+
+ # [Certificate scenario 2: JCERACFKS (z/OS Keyring) ]
+ # Type of certificate storage
+ #keystoreType="JCERACFKS"
+ # Pathname of the z/OS keyring 
+ # ** COMMONLY CUSTOMIZED **
+ #keystoreFile="safkeyringjce://STCEQA/EQAPROF.Keyring"
+ # Password to access the server certificate from the keyring
+ #keystorePass="password"
+ # ** COMMONLY CUSTOMIZED **
+ #keystorePassFile="$EQAPROF_CFG_DIR/keystore.password"
+ # Encryption key file to decrypt the encrypted keystore password
+ # ** OPTIONAL **
+ #keystorePassEncryptionKeyFile="$EQAPROF_CFG_DIR/encryption.key"
+ 
+ # [Certificate scenario 3: JCECCARACFKS (z/OS Keyring) ]
+ # Type of certificate storage
+ #keystoreType="JCECCARACFKS"
+ # Pathname of the z/OS keyring 
+ # ** COMMONLY CUSTOMIZED **
+ #keystoreFile="safkeyringjcecca://STCEQA/EQAPROF.Keyring"
+ # Password to access the server certificate from the keyring
+ #keystorePass="password"
+ # ** COMMONLY CUSTOMIZED **
+ #keystorePassFile="$EQAPROF_CFG_DIR/keystore.password"
+ # Encryption key file to decrypt the encrypted keystore password
+ # ** OPTIONAL **
+ #keystorePassEncryptionKeyFile="$EQAPROF_CFG_DIR/encryption.key"
+ 
+#---------------------------------------------------------------------
+# Liberty Generic Configurations - URL format
+#---------------------------------------------------------------------
+
+# Define the context path of the server's URI.
+# Full URL format:
+#   <protocol>://<hostname>:<port><context_path>
+# Example:
+#   https://localhost:8143/api/v1/
+context_path="/api/v1"
+
+#---------------------------------------------------------------------
+# Liberty Generic Configurations - Web Security
+#---------------------------------------------------------------------
+
+# Protocol Version Fallback
+# Allows the server to fallback to HTTP/1.0 from its default HTTP/1.1.
+# If this property is not defined, then the default is true
+# Input:
+#  - true (allow fallback) / false (disallow fallback)
+# ** OPTIONAL **
+#allowProtocolVersionFallback=true
+
+# CORS (Cross-Origin Resource Sharing)
+# Specifies the allowed origins for incoming cross-origin requests.
+# If this property is not defined, then all origins are allowed.
+# Input:
+#   - Comma-separated list with no spaces:
+#     <protocol>://<host>:<port>,<protocol>://<host>:<port>
+# ** OPTIONAL **
+#corAllowedOrigins=https://localhost:8143
+
+# Deny IP Access
+# Restricts access to requests made using the server's IP address.
+# If this property is not defined, then the default is false
+# Input:
+#   - true (deny IP access) / false (allow IP access)
+# ** OPTIONAL **
+#denyIPAddress=false
+
+# Host Header Injection Protection
+# Protects against host header injection by allowing only 
+# trusted hostnames or IPs.
+# If this property is not defined, then no host validation is done.
+# Input:
+#   - Comma-separated list with no spaces:
+#     <host>:<port>,<host>:<port>
+# ** OPTIONAL **
+#trustedHostnames=localhost:8143
+
+# HTTP Keep-Alive
+# Enables or disables persistent HTTP connections.
+# If this property is not defined, then the default is true
+# Input:
+#   - true (keep connections open for reuse)
+#   - false (close connection after each response)
+# ** OPTIONAL **
+#enableKeepAlive=true
+
+#---------------------------------------------------------------------
+# Liberty Generic Configurations - Rate Limiting
+#---------------------------------------------------------------------
+
+# Enable Rate Limiter
+# Controls whether the server limits the number of requests 
+# per second per client IP.
+# If this property is not defined, then the default is true
+# Input:
+#   - true (enable rate limiting)
+#   - false (disable rate limiting)
+# ** COMMONLY CUSTOMIZED **
+enableRateLimit=true
+
+# Requests Per Second
+# Defines the maximum number of requests allowed per second.
+# If this property is not defined, then the default is 10.0.
+# Eclipse and VSCode clients should default to 1000.0.
+# Input:
+#   - Decimal value (e.g., 10.0, 1000.0)
+# ** COMMONLY CUSTOMIZED **
+requestsPerSec=1000.0
+
+#---------------------------------------------------------------------
+# Liberty Generic Configurations - Attach API
+#---------------------------------------------------------------------
+
+# Enable Attach API
+# Enables or disables the Attach API, used by some monitoring tools
+# to connect to a running Java process from an external JVM.
+# On UNIX systems, Attach API creates a shared directory under /tmp.
+# In z/OS, this can lead to security violations console messages.
+# If this property is not defined, then the default is no
+# Input:
+#   - yes (enable Attach API)
+#   - no  (disable Attach API)
+# ** OPTIONAL **
+#enableAttachApi=no
+
+# Attach API Directory
+# Defines a custom shared directory for Attach API operations.
+# If this property is not defined, then the default is:
+#   /tmp/.com_ibm_tools_attach
+# Input:
+#   - Absolute path to a directory
+# ** OPTIONAL **
+#attachApiDir=/tmp/.com_ibm_tools_attach
+
+#---------------------------------------------------------------------
+# Liberty Generic Configurations - Monitor ALL inbound HTTP requests
+#---------------------------------------------------------------------
+
+# Enable Trace Logging
+# Enables or disables logging of ALL inbound HTTP requests
+# coming into the server.
+# By default, logs are written to:
+#   ${WRKDIR}/eqaProfile/logs/trace.log
+# Log roll-over interval defaults to once per day.
+# If this property is not defined, tracing is disabled
+# Input:
+#   - true (enable trace logging)
+#   - false (disable trace logging)
+# ** OPTIONAL **
+# enableTraceLog=false
+
+# Maximum Trace Log Files
+# Defines the maximum number of trace log files to retain
+# before older files are removed.
+# If this property is not defined, the default is 2
+# Input:
+#   - Integer
+# ** OPTIONAL **
+# traceLogMaxFiles=2
+
+# Inbound Header to Trace
+# Specifies the name of a single inbound HTTP header 
+# to include in the trace log.
+# If not defined or left empty, no inbound headers are traced.
+# Input:
+#   - HTTP Header name
+# ** OPTIONAL **
+# traceInboundHeaderName=""
+
+# Outbound Header to Trace
+# Specifies the name of a single outbound HTTP header 
+# to include in the trace log.
+# If not defined or left empty, no outbound headers are traced.
+# Input:
+#   - HTTP Header name
+# ** OPTIONAL **
+# traceOutboundHeaderName=""
+
+#---------------------------------------------------------------------
+# Liberty Generic Configurations - Swagger UI explorer
+#---------------------------------------------------------------------
+# Defines a list of servers shown in the Swagger UI explorer endpoint
+# to provide connectivity information.
+# - Users deploying AT-TLS must set this property to specify the
+#   server URL with the correct protocol, since Liberty defaults to
+#   HTTP (non-secure) and does not automatically detect
+#   AT-TLS SSL encryption.
+# - Users who prefer a different hostname must set this property to
+#   specify the desired server name.
+
+# If this property is not defined, Liberty dynamically constructs the
+# server name.
+# Input:
+#  - Comma-separated list with no spaces:
+#   <protocol>://<host>:<port>,<protocol>://<host>:<port>
+# ** OPTIONAL **
+#swaggerUIServers=https://localhost:8143,https://vipahost:8143
+
+#---------------------------------------------------------------------
+# Debug Profile Service Generic - STDOUT Logging
+#---------------------------------------------------------------------
+
+# Server Logger Level
+# Defines the logging level for generic logs (STDOUT).
+# If this property is not defined, the default level is INFO
+# Input:
+#   - OFF, INFO, DEBUG, ERROR, WARN
+# ** COMMONLY CUSTOMIZED **
+serverLoggerLevel=INFO
+
+#---------------------------------------------------------------------
+# Debug Profile Service API (DPS API) - CICS and Non-CICS profiles
+#---------------------------------------------------------------------
+
+# Define the naming pattern for EQAUOPTS data sets
+# Notes:
+# - DPS API uses the naming pattern to create, read, and delete 
+#   unique data sets per user.
+# - The ampersand (&) is a reserved character in shell scripts and
+#   must be escaped with a backslash (\).
+# - The pattern \&USERID is replaced dynamically with the user ID.
+#   For example, if the user ID is IBMUSER, the resolved name will be:
+#   IBMUSER.DLAYDBG.EQAUOPTS
+# Input:
+#   - String representing the data set naming pattern
+# ** COMMONLY CUSTOMIZED **
+default_dsname="{{ app_hlq }}.USR.\&USERID.DLAYDBG.EQAUOPTS"
+
+# Configuration File Path for CICS Region List
+# Define the pathname of the configuration file containing 
+# the list of CICS region
+# Input:
+#   - Absolute path to the configuration file
+# ** COMMONLY CUSTOMIZED **
+dtcn_ports="$EQAPROF_CFG_DIR/dtcn.ports"
+
+# STDOUT Logging
+# Defines the logging level for DPS API logs (STDOUT).
+# If this property is not defined, the default level is INFO
+# Input:
+#   - OFF, INFO, DEBUG, ERROR, WARN
+# ** COMMONLY CUSTOMIZED **
+dpsApiLoggerLevel=INFO
+
+#---------------------------------------------------------------------
+# IMS Transaction Isolation API (IMS ISO API) 
+#---------------------------------------------------------------------
+# These properties define the DD statements required by the EQANIPSB
+# program running on the engine, which provides
+# IMS transaction isolation support.
+#
+# Replace the default z/OS Debugger data set names 
+# with the data set names installed at your site.
+# For example, SEQAMOD, SEQAEXEC, SEQATLIB.
+#
+# Replace the IMS data set SDFSRESL with the one 
+# configured in your IMS environment.
+#
+# Note:
+# - The debug profile (EQAUOPTS) data set used 
+#   by  IMS Isolation Private Region
+#   is determined by the "default_dsname" parameter.
+#---------------------------------------------------------------------
+
+# EQATIPSB DD
+# Defines a comma-separated list of load libraries 
+# used by the EQANBSWT BMP program.
+# Note: EQAW.SEQAMOD must be listed and match the library used by
+#       the EQAPROF job. As defined in the STEPLIB
+#       or the system link list.
+# Input:
+#   - Comma-separated list of load libraries
+# ** COMMONLY CUSTOMIZED **
+imsiso_dd_eqatipsb={{ debug_hlq }}.SEQAMOD,{{ims_hlq}}.SDFSRESL,CEE.SCEERUN
+
+# SYSPROC DD
+# Specifies the REXX libraries used to prepare JCL 
+# for cloning the MPR job.
+# Input:
+#   - Comma-separated list of REXX libraries
+# ** COMMONLY CUSTOMIZED **
+imsiso_dd_sysproc={{ debug_hlq }}.SEQAEXEC
+
+# JCLLIB DD
+# Points to the library containing the EQAZPROC member used to analyze
+# the JCL of an existing message region.
+# Input:
+#   - Comma-separated list of JCL libraries
+# ** COMMONLY CUSTOMIZED **
+imsiso_dd_jcllib={{ debug_hlq }}.SEQATLIB
+
+# SYSLIB DD
+# ** COMMONLY CUSTOMIZED **
+imsiso_dd_syslib=SYS1.MACLIB
+
+# STDOUT Logging
+# Defines the logging level for IMS ISO API logs (STDOUT).
+# If this property is not defined, the default level is INFO
+# Input:
+#   - OFF, INFO, DEBUG, ERROR, WARN
+# ** COMMONLY CUSTOMIZED **
+imsIsoApiLoggerLevel=INFO
+
+#---------------------------------------------------------------------
+# Authentication Service API (AUTH API) 
+#---------------------------------------------------------------------
+# You can authenticate users using SAF Basic or SAF JWT authentication
+#
+#   - To use Basic authentication:
+#      No external setup is required.
+#
+#   - To use JWT authentication (recommended for higher security):
+#      External setup is required.
+#      You MUST configure RACF Identify Token (IDT) profiles on z/OS
+#      outside of this server, which define the APPLID provider.
+#
+# If neither property is defined:
+#   - Basic is disabled by default.
+#   - JWT is enabled by default.
+#
+# For backward compatibility, both authentication methods can be
+# enabled at the same time.
+#---------------------------------------------------------------------
+
+# Enable SAF/RACF Basic Authentication
+# If not defined, Basic Authentication is disabled by default
+# Input:
+#   - true or false
+# ** COMMONLY CUSTOMIZED **
+safBasicIsEnabled=false
+
+# Enable SAF/RACF JWT Authentication
+# If not defined, JWT Authentication is enabled by default
+# Input:
+#   - true or false
+# ** COMMONLY CUSTOMIZED **
+safJwtIsEnabled=true
+
+ # APPLID used to validate and generate SAF/RACF IDT (JWT token)
+ # - Eclipse: use FEKAPPL (same as RSE Daemon)
+ # - VSCode: use FEKAPPL or EQAAPPL
+ # If not defined, defaults to FEKAPPL
+ # Input:
+ #   - The APPLID name
+ # ** COMMONLY CUSTOMIZED **
+ safJwtApplId=FEKAPPL
+
+# STDOUT Logging - Authentication API
+# Defines logging level; defaults to INFO if not defined
+# Input:
+#   - OFF, INFO, DEBUG, ERROR, WARN
+# ** COMMONLY CUSTOMIZED **
+authApiLoggerLevel=INFO
+safBasicIsEnabled=true
+#  Begin Ansible Insert Block  #
+JVM_ARGS="-Xoptionsfile=/etc/debug/eqaprof.options"
+#  End Ansible of Insert Block  #

--- a/.setup/debug_config/eqaprof.env.j2
+++ b/.setup/debug_config/eqaprof.env.j2
@@ -343,7 +343,7 @@ serverLoggerLevel=INFO
 # Input:
 #   - String representing the data set naming pattern
 # ** COMMONLY CUSTOMIZED **
-default_dsname="{{ app_hlq }}.USR.\&USERID.DLAYDBG.EQAUOPTS"
+default_dsname="{{ app_hlq }}.USR.\\&USERID.DLAYDBG.EQAUOPTS"
 
 # Configuration File Path for CICS Region List
 # Define the pathname of the configuration file containing 

--- a/.setup/debug_config/eqaprof.env.j2
+++ b/.setup/debug_config/eqaprof.env.j2
@@ -343,7 +343,7 @@ serverLoggerLevel=INFO
 # Input:
 #   - String representing the data set naming pattern
 # ** COMMONLY CUSTOMIZED **
-default_dsname="{{ app_hlq }}.USR.\\&USERID.DLAYDBG.EQAUOPTS"
+default_dsname="{{ app_hlq }}.USR.\&USERID.DLAYDBG.EQAUOPTS"
 
 # Configuration File Path for CICS Region List
 # Define the pathname of the configuration file containing 

--- a/.setup/debug_config/eqaprof.env.j2
+++ b/.setup/debug_config/eqaprof.env.j2
@@ -23,7 +23,7 @@
 
 # Home directory of the 64-bit Java SDK
 # ** COMMONLY CUSTOMIZED **
-java_dir=/usr/lpp/java/java21/current_64/
+java_dir={{ java.java_home }}
     
 #---------------------------------------------------------------------
 # Define the path where Liberty is installed.
@@ -31,7 +31,7 @@ java_dir=/usr/lpp/java/java21/current_64/
 
 # Home directory of IBM z/OS Liberty Embedded web server
 # ** COMMONLY CUSTOMIZED **
-liberty_dir=/usr/lpp/liberty_zos/current
+liberty_dir={{ global.liberty_home }}
 
 #---------------------------------------------------------------------
 # Liberty Generic Configurations - Port Settings
@@ -39,7 +39,7 @@ liberty_dir=/usr/lpp/liberty_zos/current
 
 # Define the port number the server listens to for incoming requests
 # ** COMMONLY CUSTOMIZED **
-port="8192"
+port="{{ debug.eqaprof_port }}"
 
 # Define ephemeral port to stop the server or issue java dumps.
 # If it is not defined, then it is assigned dynamically by z/OS.
@@ -47,7 +47,7 @@ port="8192"
 #   - An integer from 1 to 65535 for a fixed port
 #   - Use -1 to disable the shutdown port
 # ** OPTIONAL **
-port_shutdown="8105"
+port_shutdown="{{ debug.eqaprof_port_shutdown }}"
 
 #---------------------------------------------------------------------
 # Liberty Generic Configurations - Enable/Disable Secure Communication
@@ -105,7 +105,7 @@ SECURE="Y"
 keystoreType="JCERACFKS"
  # Pathname of the keystore file
  # ** COMMONLY CUSTOMIZED **
-keystoreFile="safkeyring://STCDBG/EQAPROF_Ring"
+keystoreFile="{{ debug.eqaprof_keystore_file }}"
  # Password to access the server certificate from the keystore
  # ** COMMONLY CUSTOMIZED **
 keystorePass="password"

--- a/.setup/setup-common.sh
+++ b/.setup/setup-common.sh
@@ -470,6 +470,34 @@ stage_setup_ims_region() {
 }
 
 #########################################################
+# STAGE: Setup DPS
+#########################################################
+stage_setup_debug_profile_service() {
+    print_stage "STAGE: Configure Debug Profile Service"
+
+    # Verify script exists
+    if [ ! -f "$BANK_DIR/.setup/setup/setup-debug.sh" ]; then
+        print_error "Installation script not found: $BANK_DIR/.setup/setup/setup-debug.sh"
+        exit 1
+    fi
+    
+    # Run script
+    print_info "Running Debug Profile Service setup script..."
+    print_info "Executing: bash $BANK_DIR/.setup/setup/setup-debug.sh"
+    cd "$BANK_DIR"
+    
+    
+    set -o pipefail
+    if .setup/setup/setup-debug.sh; then
+        print_success "Debug Profile Service setup completed successfully"
+    else
+        print_error "Failed to setup Debug Profile Service"
+        exit 1
+    fi
+}
+
+
+#########################################################
 # Main execution helpers
 #########################################################
 print_phase_next_step() {
@@ -533,6 +561,8 @@ main_setup() {
         stage_setup_ims_database
         stage_setup_ims_bankz_regions
     fi
+
+    stage_setup_debug_profile_service
 
     # Certificates
     if [[ "${ZOS_CREATE_CERTS,,}" == "true" ]]; then

--- a/.setup/setup/setup-cics-region.sh
+++ b/.setup/setup/setup-cics-region.sh
@@ -205,45 +205,8 @@ python "$SCRIPTS_DIR/../lib/render_template.py" --configFile $CONFIG_FILE \
     --templateFile "$SCRIPTS_DIR/../jcl/cics/tcpip-create.j2"  --outputFile "/tmp/tcpip-create-$$.jcl"
 run_job_and_wait "/tmp/tcpip-create-$$.jcl"
 
-opercmd "S EQARMTD"
-
-# ======================================
-# Stage 5: Add CICS region to dtcn.ports
-# ======================================
-print_stage "Stage 6: Add CICS region to dtcn.ports"
 # =========================
-# Update /etc/debug/dtcn.ports
-# =========================
-DTCN_PORTS="/etc/debug/dtcn.ports"
-DTCN_PORTS_TMP="/tmp/dtcn.ports$$"
-print_info "Checking ${DTCN_PORTS} for CICS${APP_SHORT_NAME}..."
-
-if grep -Eq "^[[:space:]]*CICS${APP_SHORT_NAME}:27103([[:space:]]*)$" "${DTCN_PORTS}"; then
-    print_info "CICSBOZ already present in ${DTCN_PORTS}"
-else
-    print_info "Trying to add CICS${APP_SHORT_NAME}:27103 to ${DTCN_PORTS}"
-    set +e
-    chtag -tc IBM-1047 "$DTCN_PORTS"
-    RC=$?
-    set -e
-    if [ $RC -eq 0 ]; then
-        rm -f /tmp/dtcn.ports*
-        cp "${DTCN_PORTS}" "${DTCN_PORTS_TMP}"
-        echo "" >> "$DTCN_PORTS_TMP"
-        echo "  CICS${APP_SHORT_NAME}:27103" >> "$DTCN_PORTS_TMP"
-        cp "${DTCN_PORTS_TMP}" "$DTCN_PORTS"
-        chtag -r "$DTCN_PORTS"
-        opercmd "C EQAPROF"  
-        sleep 5
-        opercmd "S EQAPROF" 
-        sleep 5
-    else
-        print_warning "Fail adding CICS${APP_SHORT_NAME}:27103 to ${DTCN_PORTS} (maybe permission deny)."
-    fi
-fi
-
-# =========================
-# # Stage 6: Configure RACF STARTED profile
+# # Stage 5: Configure RACF STARTED profile
 # =========================
 print_info "Configuring RACF STARTED profile..."
 set +e
@@ -259,7 +222,7 @@ chown -R "$CICS_USER" "$SANDBOX_DIR/CICS${APP_SHORT_NAME}"
 set -e
 
 # =========================
-# Stage 7: Generate CICS proc
+# Stage 6: Generate CICS proc
 # =========================
 # Create JCL with each line padded to exactly 80 characters for FB80 dataset
 rm -f "/tmp/CICS${APP_SHORT_NAME}-$$.jcl"
@@ -293,7 +256,7 @@ python "$SCRIPTS_DIR/../lib/render_template.py" --configFile $CONFIG_FILE \
 dcp "/tmp/CICS${APP_SHORT_NAME}J.jcl" "${CICS_SYS_PROCLIB}(CICS${APP_SHORT_NAME}J)"
 
 # =========================
-# Stage 8: Start CICS region
+# Stage 7: Start CICS region
 # =========================
 print_stage "STAGE 5: Start CICS region"
 if [[ "$CICS_SYS_PROCLIB" != "${APP_HLQ}.PROCLIB" ]]; then
@@ -316,7 +279,7 @@ fi
 print_info ""
 
 # =========================
-# Stage 9: Cleanup
+# Stage 8: Cleanup
 # =========================
 rm -f "$zconfig_dir/EYUSMSSJ.jvmprofile"
 print_success "CICS Bank of Z setup completed"

--- a/.setup/setup/setup-debug.sh
+++ b/.setup/setup/setup-debug.sh
@@ -82,6 +82,9 @@ fi
 # =======================================================
 print_stage "Stage 3: Modify eqaprof.env to customize for BANKZ IMS"
 
+EQADREST_ENV="/etc/debug/eqadrest.env"
+cp "${EQADREST_ENV}" "${EQAPROF_CONF_DIR}/eqadrest.env"
+
 python "$SCRIPTS_DIR/../lib/render_template.py" --configFile $CONFIG_FILE \
     --extraVar "ims_hlq=${IMS_APP_HLQ}" \
     --extraVar "debug_hlq=${DEBUG_HLQ}" \
@@ -94,7 +97,7 @@ python "$SCRIPTS_DIR/../lib/render_template.py" --configFile $CONFIG_FILE \
 # ===================================
 set +e
 print_stage "Stage 4: Start EQAPROF task"
-opercmd "S EQAPROF,CFGDIR=${EQAPROF_CONF_DIR}" 
+opercmd -p "S EQAPROF,CFGDIR='${EQAPROF_CONF_DIR}'" 
 
 if netstat | grep -q "EQARMTD"
 then 

--- a/.setup/setup/setup-debug.sh
+++ b/.setup/setup/setup-debug.sh
@@ -85,7 +85,7 @@ print_stage "Stage 3: Modify eqaprof.env to customize for BANKZ IMS"
 python "$SCRIPTS_DIR/../lib/render_template.py" --configFile $CONFIG_FILE \
     --extraVar "ims_hlq=${IMS_APP_HLQ}" \
     --extraVar "debug_hlq=${DEBUG_HLQ}" \
-    --extraVar ="app_hlq=${APP_HLQ}" \
+    --extraVar "app_hlq=${APP_HLQ}" \
     --templateFile "$SCRIPTS_DIR/../debug_config/eqaprof.env.j2"  --outputFile "${EQAPROF_CONF_DIR}/eqaprof.env"
 
 

--- a/.setup/setup/setup-debug.sh
+++ b/.setup/setup/setup-debug.sh
@@ -56,11 +56,11 @@ DTCN_PORTS="/etc/debug/dtcn.ports"
 DTCN_PORTS_TMP="/tmp/dtcn.ports$$"
 print_info "Checking ${DTCN_PORTS} for CICS${APP_SHORT_NAME}..."
 
-if grep -Eq "^[[:space:]]*CICS${APP_SHORT_NAME}:27103([[:space:]]*)$" "${DTCN_PORTS}"; then
+if grep -Eq "^[[:space:]]*CICS${APP_SHORT_NAME}:${CICS_DEBUG_PORT}([[:space:]]*)$" "${DTCN_PORTS}"; then
     print_info "CICSBOZ already present in ${DTCN_PORTS}"
     cp "${DTCN_PORTS}" "${EQAPROF_CONF_DIR}/dtcn.ports"
 else
-    print_info "Trying to add CICS${APP_SHORT_NAME}:27103 to ${DTCN_PORTS}"
+    print_info "Trying to add CICS${APP_SHORT_NAME}:${CICS_DEBUG_PORT} to ${DTCN_PORTS}"
     set +e
     chtag -tc IBM-1047 "$DTCN_PORTS"
     RC=$?
@@ -69,11 +69,11 @@ else
         rm -f /tmp/dtcn.ports*
         cp "${DTCN_PORTS}" "${DTCN_PORTS_TMP}"
         echo "" >> "$DTCN_PORTS_TMP"
-        echo "  CICS${APP_SHORT_NAME}:27103" >> "$DTCN_PORTS_TMP"
+        echo "  CICS${APP_SHORT_NAME}:${CICS_DEBUG_PORT}" >> "$DTCN_PORTS_TMP"
         cp "${DTCN_PORTS_TMP}" "${EQAPROF_CONF_DIR}/dtcn.ports"
         chtag -r "$DTCN_PORTS"
     else
-        print_warning "Fail adding CICS${APP_SHORT_NAME}:27103 to ${DTCN_PORTS} (maybe permission deny)."
+        print_warning "Fail adding CICS${APP_SHORT_NAME}:${CICS_DEBUG_PORT} to ${DTCN_PORTS} (maybe permission deny)."
     fi
 fi
 

--- a/.setup/setup/setup-debug.sh
+++ b/.setup/setup/setup-debug.sh
@@ -1,0 +1,107 @@
+#!/bin/env bash
+set -eu
+
+# =============================================================================
+# Script  : setup-debug.sh
+# Summary : Configure Debug Profile Service (DPS, EQAPROF) to work with 
+#           Bank of Z CICS and IMS regions
+#
+# Runs on the remote z/OS USS system after the workspace has been cloned.
+# - Verifies prerequisites
+# - Stops EQAPROF task
+# - Configures dtcn.ports for CICS
+# - Configures eqaprof.env for IMS
+# - Starts debug services
+# =============================================================================
+
+# =========================
+# Source library scripts
+# =========================
+SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPTS_DIR/../config/setenv.sh"
+
+exec > >(while IFS= read -r line; do
+    line="${line%"${line##*[![:space:]]}"}"
+    [[ -z "$line" ]] && continue
+    printf "${CYAN}[DEBUG]${NC} %s\n" "${line}" 2>/dev/null || true
+done) 2>&1
+
+# =========================
+# Environment
+# =========================
+export PATH="$ZOAU_HOME/bin:$PATH"
+export LIBPATH="$ZOAU_HOME/lib:${LIBPATH:-}"
+export CICS_REGION="CICS${APP_SHORT_NAME}"
+
+# =========================
+# Stage 1: Stop EQAPROF
+# =========================
+set +e
+print_stage "Stage 1: Stop EQAPROF task"
+opercmd "C EQAPROF" 
+sleep 5
+
+mkdir -p "${EQAPROF_CONF_DIR}"
+set -e
+
+
+# ======================================
+# Stage 2: Add CICS region to dtcn.ports
+# ======================================
+print_stage "Stage 2: Add CICS region to dtcn.ports"
+# =========================
+# Update /etc/debug/dtcn.ports
+# =========================
+DTCN_PORTS="/etc/debug/dtcn.ports"
+DTCN_PORTS_TMP="/tmp/dtcn.ports$$"
+print_info "Checking ${DTCN_PORTS} for CICS${APP_SHORT_NAME}..."
+
+if grep -Eq "^[[:space:]]*CICS${APP_SHORT_NAME}:27103([[:space:]]*)$" "${DTCN_PORTS}"; then
+    print_info "CICSBOZ already present in ${DTCN_PORTS}"
+    cp "${DTCN_PORTS}" "${EQAPROF_CONF_DIR}/dtcn.ports"
+else
+    print_info "Trying to add CICS${APP_SHORT_NAME}:27103 to ${DTCN_PORTS}"
+    set +e
+    chtag -tc IBM-1047 "$DTCN_PORTS"
+    RC=$?
+    set -e
+    if [ $RC -eq 0 ]; then
+        rm -f /tmp/dtcn.ports*
+        cp "${DTCN_PORTS}" "${DTCN_PORTS_TMP}"
+        echo "" >> "$DTCN_PORTS_TMP"
+        echo "  CICS${APP_SHORT_NAME}:27103" >> "$DTCN_PORTS_TMP"
+        cp "${DTCN_PORTS_TMP}" "${EQAPROF_CONF_DIR}/dtcn.ports"
+        chtag -r "$DTCN_PORTS"
+    else
+        print_warning "Fail adding CICS${APP_SHORT_NAME}:27103 to ${DTCN_PORTS} (maybe permission deny)."
+    fi
+fi
+
+# =======================================================
+# Stage 3: Modify eqaprof.env to customize for BANKZ IMS
+# =======================================================
+print_stage "Stage 3: Modify eqaprof.env to customize for BANKZ IMS"
+
+python "$SCRIPTS_DIR/../lib/render_template.py" --configFile $CONFIG_FILE \
+    --extraVar "ims_hlq=${IMS_APP_HLQ}" \
+    --extraVar "debug_hlq=${DEBUG_HLQ}" \
+    --templateFile "$SCRIPTS_DIR/../debug_config/eqaprof.env.j2"  --outputFile "${EQAPROF_CONF_DIR}/eqaprof.env"
+
+
+# ===================================
+# Stage 4: Start EQAPROF and EQARMTD
+# ===================================
+set +e
+print_stage "Stage 4: Start EQAPROF task"
+opercmd "S EQAPROF,CFGDIR=${EQAPROF_CONF_DIR}" 
+
+if netstat | grep -q "EQARMTD"
+then 
+    echo "EQARMTD is started";
+else
+    echo "Starting Remote Debug Service (EQARMTD)"
+    opercmd "S EQARMTD"
+fi
+sleep 5
+
+set -e

--- a/.setup/setup/setup-debug.sh
+++ b/.setup/setup/setup-debug.sh
@@ -85,6 +85,7 @@ print_stage "Stage 3: Modify eqaprof.env to customize for BANKZ IMS"
 python "$SCRIPTS_DIR/../lib/render_template.py" --configFile $CONFIG_FILE \
     --extraVar "ims_hlq=${IMS_APP_HLQ}" \
     --extraVar "debug_hlq=${DEBUG_HLQ}" \
+    --extraVar ="app_hlq=${APP_HLQ}" \
     --templateFile "$SCRIPTS_DIR/../debug_config/eqaprof.env.j2"  --outputFile "${EQAPROF_CONF_DIR}/eqaprof.env"
 
 


### PR DESCRIPTION
This PR follows https://github.com/IBM/Bank-of-Z/pull/212 complete setting up debug in IMS. The goal is to configure Debug Profile Service (DPS) for BANKZ IMS2 system; as this requires restarting DPS and it is already restarted once during CICS region setup, I decided to move DPS configuration into a separate stage setup-debug.sh, that runs after cics and ims have been set up. The script customizes for both CICS (dtcn.ports) and IMS (eqaprof.env).

To avoid permission issues it copies all 3 eqaprof config files: dtcn.ports, eqaprof.env and eqadrest.env into /usr/local/sandboxes/bank-of-z/debug/ where the build user is supposedly allowed to write and starts EQAPROF task with CFGDIR parameter pointing there.