### PR TITLE
Allow alternate build directories

### DIFF
--- a/.setup/pipeline-common.sh
+++ b/.setup/pipeline-common.sh
@@ -259,6 +259,18 @@ main() {
     else
         # Detect Execution Mode
         detect_bank_of_z_location
+
+        # Re-anchor DBB and tool paths to the resolved repo location.
+        # setenv.sh bakes these in from config.yaml using the static sandbox
+        # path; when running in a pipeline workspace the resolved BANK_DIR
+        # differs from that static path, so we override them here.
+        export DBB_CWD="${BANK_DIR}/"
+        export DBB_APP_CONF="${BANK_DIR}/dbb-app.yaml"
+        export SCAN_SOURCE_FOLDER="${BANK_DIR}/src/base"
+        export SCAN_RULE_FILE="${BANK_DIR}/zcodescan/zcodescan-rules.yaml"
+        export DEPLOY_DEPLOYMENT_METHOD="${BANK_DIR}/.setup/deploy/deployment-method.yml"
+        export DEPLOY_ENV_FILE="${BANK_DIR}/.setup/deploy/Development.yml"
+        export DEPLOY_TYPES_MAPPING_FILES="${BANK_DIR}/.setup/deploy/types_pattern_mapping.yml"
     fi
     
     case "$phase" in

--- a/.setup/tasks/task-dbb-build.sh
+++ b/.setup/tasks/task-dbb-build.sh
@@ -20,7 +20,8 @@ set -eu
 # Source library scripts
 # =========================
 SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPTS_DIR/../config/setenv.sh"
+source "$SCRIPTS_DIR/../lib/utilities.sh"
+source "$SCRIPTS_DIR/../lib/colors.sh"
 
 exec > >(while IFS= read -r line; do
     line="${line%"${line##*[![:space:]]}"}"

--- a/.setup/tasks/task-install-verification.sh
+++ b/.setup/tasks/task-install-verification.sh
@@ -4,7 +4,7 @@ set -eu
 # Script  : task-install-verification.sh
 # Summary : Post-install Verification Tests
 #
-# - Sources setenv.sh to resolve BASE_URL / FRONTEND_URL via test-setup.sh
+# - Relies on environment exported by pipeline-common.sh / setup-common.sh
 # - Exports IMS_DISABLED (defaults to false)
 # - Makes all test scripts executable
 # - Runs tests/run-all.sh and reports pass/fail
@@ -14,7 +14,8 @@ set -eu
 # Source library scripts
 # =========================
 SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPTS_DIR/../config/setenv.sh"
+source "$SCRIPTS_DIR/../lib/utilities.sh"
+source "$SCRIPTS_DIR/../lib/colors.sh"
 
 exec > >(while IFS= read -r line; do
     line="${line%"${line##*[![:space:]]}"}"

--- a/.setup/tasks/task-wazi-deploy.sh
+++ b/.setup/tasks/task-wazi-deploy.sh
@@ -4,8 +4,8 @@ set -eu
 # Script  : task-wazi-deploy.sh
 # Summary : Wazi Deploy Generate + Deploy
 #
-# - Initializes execution environment
-# - Loads Wazi Deploy configuration from setenv.sh
+# - Relies on environment exported by pipeline-common.sh / setup-common.sh
+# - Loads Wazi Deploy configuration from inherited environment variables
 # - Creates timestamped output and evidence directories
 # - Executes wazideploy-generate
 # - Executes wazideploy-deploy
@@ -18,7 +18,8 @@ set -eu
 # Source library scripts
 # =========================
 SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPTS_DIR/../config/setenv.sh"
+source "$SCRIPTS_DIR/../lib/utilities.sh"
+source "$SCRIPTS_DIR/../lib/colors.sh"
 
 exec > >(while IFS= read -r line; do
     line="${line%"${line##*[![:space:]]}"}"

--- a/.setup/tasks/task-zcodescan-static-scan.sh
+++ b/.setup/tasks/task-zcodescan-static-scan.sh
@@ -17,7 +17,8 @@ set -eu
 # Source library scripts
 # =========================
 SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPTS_DIR/../config/setenv.sh"
+source "$SCRIPTS_DIR/../lib/utilities.sh"
+source "$SCRIPTS_DIR/../lib/colors.sh"
 
 exec > >(while IFS= read -r line; do
     line="${line%"${line##*[![:space:]]}"}"


### PR DESCRIPTION
I noticed that when running `pipeline-common.sh` from a different directory, and not having patched the `config.yaml`, the build keeps executing from the default location.

This PR allows running them from alternative folder structures. 

Initial problem addressed - when detecting of the correct repository location, however not inherited in the build stage.

```
=================================================================
= Detecting Bank of Z location...
=================================================================

[INFO] Running from within Bank-of-Z repository
[INFO] Repository location: /usr/local/sandboxes/bank-of-z/pipeline/dennis-behm/Bank-of-Z/feature/implement-github-actions-pipeline/build_f61/Bank-of-Z
[SUCCESS] Using current repository (GRUB workflow detected)

[INFO] Running on: z/OS VS01 02.00 03 8561


=================================================================
= STAGE 1: Build Bank of Z
=================================================================

[INFO] Running Bank of Z build script...
[INFO] Executing: bash /usr/local/sandboxes/bank-of-z/pipeline/dennis-behm/Bank-of-Z/feature/implement-github-actions-pipeline/build_f61/Bank-of-Z/.setup/tasks/task-dbb-build.sh 
[INFO] All variables are properly set.
[DBB-BUILD] [INFO] Running PIPELINE (impact) DBB build
[DBB-BUILD] [INFO] Starting DBB build in /usr/local/sandboxes/bank-of-z/Bank-of-Z/ ...
[DBB-BUILD] [INFO] IBM Dependency Based Build 3.0.5.2
```