### PR TITLE
Reduce time to prepare the environment file

### DIFF
--- a/.setup/config/setenv.sh
+++ b/.setup/config/setenv.sh
@@ -32,12 +32,14 @@ fi
 set -e
 
 
+TEMPLATE_FILE="${LOCAL_SCRIPTS_DIR}/.env.template"
+
 if [[ ! -f "$ENV_FILE" || "$ENV_FILE" -ot "$CONFIG_FILE" || "$ENV_FILE" -ot "${BASH_SOURCE[0]}" ]]; then
     print_warning "Creating $ENV_FILE file ..."
     print_warning " - Not already exists or not in sync with:"
     print_warning "   - '$CONFIG_FILE'"
     print_warning "   - '${BASH_SOURCE[0]}'"
-    cat > "$ENV_FILE" <<EOF
+    cat > "$TEMPLATE_FILE" <<'EOF'
 # =========================
 # Environment
 # =========================
@@ -45,131 +47,132 @@ if [[ ! -f "$ENV_FILE" || "$ENV_FILE" -ot "$CONFIG_FILE" || "$ENV_FILE" -ot "${B
 # Global
 _BPXK_AUTOCVT=ON
 PYTHONUNBUFFERED=1
-ZOS_CURRENT_USER=$(get_section_value 'global' 'zos_current_user')
-ZOS_ADMIN_USER=$(get_section_value 'global' 'zos_admin_user')
-ZOS_CA_LABEL=$(get_section_value 'global' 'zos_ca_label')
-ZOS_KEYRING=$(get_section_value 'global' 'zos_keyring')
-ZOS_CREATE_CERTS=$(get_section_value 'global' 'zos_create_certs')
+ZOS_CURRENT_USER="{{ global.zos_current_user }}"
+ZOS_ADMIN_USER="{{ global.zos_admin_user }}"
+ZOS_CA_LABEL="{{ global.zos_ca_label }}"
+ZOS_KEYRING="{{ global.zos_keyring }}"
+ZOS_CREATE_CERTS="{{ global.zos_create_certs }}"
 
- # Application
-APP_BASE_NAME=$(get_section_value 'app' 'base_name')
-APP_SHORT_NAME=$(get_section_value 'app' 'short_name')
-APP_BASE_NAME_LOWER=$(echo "$(get_section_value 'app' 'base_name')" | tr '[:upper:]' '[:lower:]')
-APP_ZOS_VERSION=$(get_section_value 'app' 'zos_version')
-APP_FULL_VERSION=$(get_section_value 'app' 'full_version')
-APP_DESCRIPTION="$(get_section_value 'app' 'description')"
-APP_HLQ="$(get_section_value 'app' 'app_hlq')"
+# Application
+APP_BASE_NAME="{{ app.base_name }}"
+APP_SHORT_NAME="{{ app.short_name }}"
+APP_BASE_NAME_LOWER="{{ app.base_name | lower }}"
+APP_ZOS_VERSION="{{ app.zos_version }}"
+APP_FULL_VERSION="{{ app.full_version }}"
+APP_DESCRIPTION="{{ app.description }}"
+APP_HLQ="{{ app.app_hlq }}"
 
 # Sandbox
-SANDBOX_DIR=${SANDBOX_DIR:-$(get_section_value 'sandbox' 'path')}
+SANDBOX_DIR="${SANDBOX_DIR:-{{ sandbox.path }}}"
 
 # Java
-JAVA_HOME=$(get_section_value 'java' 'java_home')
+JAVA_HOME="{{ java.java_home }}"
 
 # Python
-PYTHON_HOME=$(get_section_value 'python' 'python_home')
+PYTHON_HOME="{{ python.python_home }}"
 
 # Repositories
-DBB_REPO_URL=$(get_section_value 'repositories' 'dbb_url')
+DBB_REPO_URL="{{ repositories.dbb_url }}"
 
 # ZOAU
-ZOAU_HOME="${ZOAU_HOME:-$(get_section_value 'zoau' 'zoau_home')}"
+ZOAU_HOME="${ZOAU_HOME:-{{ zoau.zoau_home }}}"
 
 # ZBuilder
-ZBUILDER_SOURCE=$(get_section_value 'zbuilder' 'source_dir')
-ZBUILDER_TARGET=$(get_section_value 'zbuilder' 'target_dir')
+ZBUILDER_SOURCE="{{ zbuilder.source_dir }}"
+ZBUILDER_TARGET="{{ zbuilder.target_dir }}"
 
 # DBB
-DBB_HOME=$(get_section_value 'dbb' 'dbb_home')
-DBB_BUILD=$(get_section_value 'dbb' 'dbb_build')
-DBB_CWD=$(get_section_value 'dbb' 'dbb_cwd')
-DBB_APP_CONF=$(get_section_value 'dbb' 'dbb_app_conf')
-DBB_LOG_FOLDER=$(get_section_value 'dbb' 'dbb_log_dir')
-DBB_BUILD_PATH=$(get_section_value 'dbb' 'dbb_build')
-DBB_LOG_FOLDER="${DBB_LOG_FOLDER:-$(get_section_value 'dbb' 'dbb_log_dir')}"
+DBB_HOME="{{ dbb.dbb_home }}"
+DBB_BUILD="{{ dbb.dbb_build }}"
+DBB_CWD="{{ dbb.dbb_cwd }}"
+DBB_APP_CONF="{{ dbb.dbb_app_conf }}"
+DBB_LOG_FOLDER="${DBB_LOG_FOLDER:-{{ dbb.dbb_log_dir }}}"
+DBB_BUILD_PATH="{{ dbb.dbb_build }}"
 
 # Wazi Deploy
-DEPLOY_WAZIDEPLOY_HOME="${DEPLOY_WAZIDEPLOY_HOME:-$(get_section_value 'wazideploy' 'wazideploy_home')}"
-DEPLOY_PYENV_ACTIVATE_PATH="${DEPLOY_PYENV_ACTIVATE_PATH:-$(get_section_value 'wazideploy' 'wazideploy_home')/bin/activate}"
-DEPLOY_DEPLOYMENT_METHOD="${DEPLOY_DEPLOYMENT_METHOD:-$(get_section_value 'wazideploy' 'deployment_method')}"
-DEPLOY_ENV_FILE="${DEPLOY_ENV_FILE:-$(get_section_value 'wazideploy' 'deployment_envfile')}"
-DEPLOY_ZDEPLOY_FOLDER="${DEPLOY_ZDEPLOY_FOLDER:-$(get_section_value 'wazideploy' 'zdeploy_dir')}"
-DEPLOY_LOG_FOLDER="${DEPLOY_LOG_FOLDER:-$(get_section_value 'wazideploy' 'deploy_log_dir')}"
-DEPLOY_TYPES_MAPPING_FILES="${DEPLOY_TYPES_MAPPING_FILES:-$(get_section_value 'wazideploy' 'types_pattern_mapping')}"
+DEPLOY_WAZIDEPLOY_HOME="${DEPLOY_WAZIDEPLOY_HOME:-{{ wazideploy.wazideploy_home }}}"
+DEPLOY_PYENV_ACTIVATE_PATH="${DEPLOY_PYENV_ACTIVATE_PATH:-{{ wazideploy.wazideploy_home }}/bin/activate}"
+DEPLOY_DEPLOYMENT_METHOD="${DEPLOY_DEPLOYMENT_METHOD:-{{ wazideploy.deployment_method }}}"
+DEPLOY_ENV_FILE="${DEPLOY_ENV_FILE:-{{ wazideploy.deployment_envfile }}}"
+DEPLOY_ZDEPLOY_FOLDER="${DEPLOY_ZDEPLOY_FOLDER:-{{ wazideploy.zdeploy_dir }}}"
+DEPLOY_LOG_FOLDER="${DEPLOY_LOG_FOLDER:-{{ wazideploy.deploy_log_dir }}}"
+DEPLOY_TYPES_MAPPING_FILES="${DEPLOY_TYPES_MAPPING_FILES:-{{ wazideploy.types_pattern_mapping }}}"
 
 # ZCodeScan
-SCAN_PYENV_ACTIVATE_PATH=${PYENV_ACTIVATE_PATH:-$(get_section_value 'zcodescan' 'zcodescan_home')/bin/activate}
-SCAN_CWD_FOLDER=${SCAN_CWD_FOLDER:-$(get_section_value 'zcodescan' 'cwd_dir')}
-SCAN_SOURCE_FOLDER=${SCAN_SOURCE_FOLDER:-$(get_section_value 'zcodescan' 'src_dir')}
-SCAN_OUTPUT_FOLDER=${SCAN_OUTPUT_FOLDER:-$(get_section_value 'zcodescan' 'output_dir')}
-SCAN_RULE_FILE=${SCAN_RULE_FILE:-$(get_section_value 'zcodescan' 'rule_file')}
-SCAN_ENCODING=${SCAN_ENCODING:-$(get_section_value 'zcodescan' 'src_encoding')}
-SCAN_CONFIG_FILE=${SCAN_CONFIG_FILE:-$(get_section_value 'zcodescan' 'config_file')}
-SCAN_MAX_RC=${SCAN_MAX_RC:-$(get_section_value 'zcodescan' 'max_rc')}
+SCAN_PYENV_ACTIVATE_PATH="${SCAN_PYENV_ACTIVATE_PATH:-{{ zcodescan.zcodescan_home }}/bin/activate}"
+SCAN_CWD_FOLDER="${SCAN_CWD_FOLDER:-{{ zcodescan.cwd_dir }}}"
+SCAN_SOURCE_FOLDER="${SCAN_SOURCE_FOLDER:-{{ zcodescan.src_dir }}}"
+SCAN_OUTPUT_FOLDER="${SCAN_OUTPUT_FOLDER:-{{ zcodescan.output_dir }}}"
+SCAN_RULE_FILE="${SCAN_RULE_FILE:-{{ zcodescan.rule_file }}}"
+SCAN_ENCODING="${SCAN_ENCODING:-{{ zcodescan.src_encoding }}}"
+SCAN_CONFIG_FILE="${SCAN_CONFIG_FILE:-{{ zcodescan.config_file }}}"
+SCAN_MAX_RC="${SCAN_MAX_RC:-{{ zcodescan.max_rc }}}"
 
 # z/OS Connect
-ZOSCONNECT_HOME=$(get_section_value 'zosconnect' 'zosconnect_home')
-ZOSCONNECT_HTTP_PORT=$(get_section_value 'zosconnect' 'http_port')
-ZOSCONNECT_HTTPS_PORT=$(get_section_value 'zosconnect' 'https_port')
-ZOSCONNECT_SERVER_FOLDER="${ZOSCONNECT_SERVER_FOLDER:-$(get_section_value 'zosconnect' 'server_dir')/servers/$(echo "$(get_section_value 'app' 'base_name')" | tr '[:upper:]' '[:lower:]')Server}"
-ZOSCONNECT_SYS_PROCLIB=$(get_section_value 'zosconnect' 'sys_proclib')
-ZOSCONNECT_TASK_USER=$(get_section_value 'zosconnect' 'task_user')
+ZOSCONNECT_HOME="{{ zosconnect.zosconnect_home }}"
+ZOSCONNECT_HTTP_PORT="{{ zosconnect.http_port }}"
+ZOSCONNECT_HTTPS_PORT="{{ zosconnect.https_port }}"
+ZOSCONNECT_SERVER_FOLDER="${ZOSCONNECT_SERVER_FOLDER:-{{ zosconnect.server_dir }}/servers/{{ app.base_name | lower }}Server}"
+ZOSCONNECT_SYS_PROCLIB="{{ zosconnect.sys_proclib }}"
+ZOSCONNECT_TASK_USER="{{ zosconnect.task_user }}"
 
 # Frontend
-FRONTEND_LIBERTY_HOME=$(get_section_value 'frontend' 'liberty_home')
-FRONTEND_HTTP_PORT=$(get_section_value 'frontend' 'http_port')
-FRONTEND_HTTPS_PORT=$(get_section_value 'frontend' 'https_port')
-FRONTEND_SYS_PROCLIB=$(get_section_value 'frontend' 'sys_proclib')
-FRONTEND_TASK_USER=$(get_section_value 'frontend' 'task_user')
+FRONTEND_LIBERTY_HOME="{{ frontend.liberty_home }}"
+FRONTEND_HTTP_PORT="{{ frontend.http_port }}"
+FRONTEND_HTTPS_PORT="{{ frontend.https_port }}"
+FRONTEND_SYS_PROCLIB="{{ frontend.sys_proclib }}"
+FRONTEND_TASK_USER="{{ frontend.task_user }}"
 
 # CICS
-CICS_USER=${CICS_USER:-$(get_section_value 'cics' 'user')}
-CICS_PASSWORD=${CICS_PASSWORD:-$(get_section_value 'cics' 'password')} #pragma: allowlist secret
-CICS_IPIC_PORT=$(get_section_value 'cics' 'ipic_port')
-CICS_CMCI_PORT=${CICS_CMCI_PORT:-$(get_section_value 'cics' 'cmci_port')}
-CICS_DEBUG_PORT=${CICS_DEBUG_PORT:-$(get_section_value 'cics' 'debug_port')}
-CICS_HLQ=${CICS_HLQ:-$(get_section_value 'cics' 'cics_hlq')}
-CICS_USS_DIR=${CICS_USS_DIR:-$(get_section_value 'cics' 'uss_dir')}
-CICS_SEC=${CICS_SEC:-$(get_section_value 'cics' 'cics_sec')}
-CICS_SYS_PROCLIB=$(get_section_value 'cics' 'sys_proclib')
-CICS_HOST=${CICS_HOST:-$(get_section_value 'cics' 'host')}
+CICS_USER="${CICS_USER:-{{ cics.user }}}"
+CICS_PASSWORD="${CICS_PASSWORD:-{{ cics.password }}}" #pragma: allowlist secret
+CICS_IPIC_PORT="{{ cics.ipic_port }}"
+CICS_CMCI_PORT="${CICS_CMCI_PORT:-{{ cics.cmci_port }}}"
+CICS_DEBUG_PORT="${CICS_DEBUG_PORT:-{{ cics.debug_port }}}"
+CICS_HLQ="${CICS_HLQ:-{{ cics.cics_hlq }}}"
+CICS_USS_DIR="${CICS_USS_DIR:-{{ cics.uss_dir }}}"
+CICS_SEC="${CICS_SEC:-{{ cics.cics_sec }}}"
+CICS_SYS_PROCLIB="{{ cics.sys_proclib }}"
+CICS_HOST="${CICS_HOST:-{{ cics.host }}}"
 
 # IMS
-IMS_DISABLED=${IMS_DISABLED:-$(get_section_value 'ims' 'disabled')}
-IMS_APP_HLQ=${IMS_APP_HLQ:-$(get_section_value 'ims' 'ims_hlq')}
-IMS_SYS_HLQ=${IMS_SYS_HLQ:-$(get_section_value 'ims' 'ims_sys_hlq')}
-IMS_HOST=${IMS_HOST:-$(get_section_value 'ims' 'host')}
-IMS_PORT=${IMS_PORT:-$(get_section_value 'ims' 'port')}
-IMS_USER=${IMS_USER:-$(get_section_value 'ims' 'user')}
-IMS_PASSWORD=${IMS_PASSWORD:-$(get_section_value 'ims' 'password')} #pragma: allowlist secret
-IMS_DATASTORE=${IMS_DATASTORE:-$(get_section_value 'ims' 'datastore')}
-IMS_PLEX=${IMS_PLEX:-$(get_section_value 'ims' 'dfs_imsplex')}
-IMS_JAVA_CONF_PATH=${IMS_JAVA_CONF_PATH:-$(get_section_value 'ims' 'java_conf_path')}
-IMS_DFS_IMS_SSID=${IMS_DFS_IMS_SSID:-$(get_section_value 'ims' 'dfs_ims_ssid')}
-IMS_JAVA_FOLDER="${IMS_JAVA_FOLDER:-$(get_section_value 'ims' 'ims_java_dir')}"
-IMS_JAVA_HOME="${IMS_JAVA_HOME:-$(get_section_value 'ims' 'ims_java_home')}"
-IMS_IXVOLSER="${IMS_IXVOLSER:-$(get_section_value 'ims' 'ixvolser')}"
-IMS_IRLM_ENABLEMENT="${IMS_IRLM_ENABLEMENT:-$(get_section_value 'ims' 'irlm_enablement')}"
-IMS_DATABASE_LOCK_MANAGER_SERVER_NAME="${IMS_DATABASE_LOCK_MANAGER_SERVER_NAME:-$(get_section_value 'ims' 'database_lock_manager_server_name')}"
+IMS_DISABLED="${IMS_DISABLED:-{{ ims.disabled }}}"
+IMS_APP_HLQ="${IMS_APP_HLQ:-{{ ims.ims_hlq }}}"
+IMS_SYS_HLQ="${IMS_SYS_HLQ:-{{ ims.ims_sys_hlq }}}"
+IMS_HOST="${IMS_HOST:-{{ ims.host }}}"
+IMS_PORT="${IMS_PORT:-{{ ims.port }}}"
+IMS_USER="${IMS_USER:-{{ ims.user }}}"
+IMS_PASSWORD="${IMS_PASSWORD:-{{ ims.password }}}" #pragma: allowlist secret
+IMS_DATASTORE="${IMS_DATASTORE:-{{ ims.datastore }}}"
+IMS_PLEX="${IMS_PLEX:-{{ ims.dfs_imsplex }}}"
+IMS_JAVA_CONF_PATH="${IMS_JAVA_CONF_PATH:-{{ ims.java_conf_path }}}"
+IMS_DFS_IMS_SSID="${IMS_DFS_IMS_SSID:-{{ ims.dfs_ims_ssid }}}"
+IMS_JAVA_FOLDER="${IMS_JAVA_FOLDER:-{{ ims.ims_java_dir }}}"
+IMS_JAVA_HOME="${IMS_JAVA_HOME:-{{ ims.ims_java_home }}}"
+IMS_IXVOLSER="${IMS_IXVOLSER:-{{ ims.ixvolser }}}"
+IMS_IRLM_ENABLEMENT="${IMS_IRLM_ENABLEMENT:-{{ ims.irlm_enablement }}}"
+IMS_DATABASE_LOCK_MANAGER_SERVER_NAME="${IMS_DATABASE_LOCK_MANAGER_SERVER_NAME:-{{ ims.database_lock_manager_server_name }}}"
 
 # zconfig
-ZCONFIG_ZCB_HOME=$(get_section_value 'zconfig' 'zcb_home')
-ZCONFIG_HOME="${ZCONFIG_HOME:-$(get_section_value 'zconfig' 'zconfig_home')}"
+ZCONFIG_ZCB_HOME="{{ zconfig.zcb_home }}"
+ZCONFIG_HOME="${ZCONFIG_HOME:-{{ zconfig.zconfig_home }}}"
 
 # Debug
-DEBUG_HLQ=$(get_section_value 'debug' 'debug_hlq')
-DEBUG_TCPIP_HQL=$(get_section_value 'debug' 'tcpip_hlq')
-EQAPROF_CONF_DIR=$(get_section_value 'debug' 'eqaprof_conf_dir')
+DEBUG_HLQ="{{ debug.debug_hlq }}"
+DEBUG_TCPIP_HQL="{{ debug.tcpip_hlq }}"
+EQAPROF_CONF_DIR="{{ debug.eqaprof_conf_dir }}"
 
 # Db2
-DB2_HLQ="${DB2_HLQ:-$(get_section_value 'db2' 'db2_hlq')}"
-DB2_SSID="${DB2_SSID:-$(get_section_value 'db2' 'ssid')}"
-DB2_JAVA_FOLDER="${DB2_JAVA_FOLDER:-$(get_section_value 'db2' 'db2_java_dir')}"
+DB2_HLQ="${DB2_HLQ:-{{ db2.db2_hlq }}}"
+DB2_SSID="${DB2_SSID:-{{ db2.ssid }}}"
+DB2_JAVA_FOLDER="${DB2_JAVA_FOLDER:-{{ db2.db2_java_dir }}}"
 
 # Zowe Configuration
-ZOWE_RSE_PROFILE=$(get_section_value 'zowe' 'rse_profile')
-RSE_PROFILE_ARG="--rse-profile $(get_section_value 'zowe' 'rse_profile')"
+ZOWE_RSE_PROFILE="{{ zowe.rse_profile }}"
+RSE_PROFILE_ARG="--rse-profile {{ zowe.rse_profile }}"
 EOF
+    python3 "$LIB_DIR/config.py" --resolve-template "$TEMPLATE_FILE" > "$ENV_FILE"
+    rm -f "$TEMPLATE_FILE"
 fi
 
 set -a

--- a/.setup/lib/config.py
+++ b/.setup/lib/config.py
@@ -88,21 +88,35 @@ def get_value(config, section, key):
     return value
 
 
+def resolve_template(config, template_file):
+    with open(template_file, "r", encoding="utf-8") as fd:
+        template_text = fd.read()
+    return Template(template_text).render(config)
+
+
 def main():
     config_file = os.environ.get("CONFIG_FILE")
     if not config_file:
         print("CONFIG_FILE environment variable is not defined", file=sys.stderr)
         sys.exit(1)
+
+    config = load_config(config_file)
+    config = render_config(config)
+
+    if len(sys.argv) == 3 and sys.argv[1] == "--resolve-template":
+        print(resolve_template(config, sys.argv[2]))
+        return
+
     if len(sys.argv) != 3:
         print(
-            f"Usage: {sys.argv[0]} <section> <key>",
+            f"Usage: {sys.argv[0]} <section> <key>\n"
+            f"       {sys.argv[0]} --resolve-template <template_file>",
             file=sys.stderr,
         )
         sys.exit(1)
+
     section = sys.argv[1]
     key = sys.argv[2]
-    config = load_config(config_file)
-    config = render_config(config)
     value = get_value(config, section, key)
     print(value)
 


### PR DESCRIPTION
## Summary

(Generated with help from IBM Bob)

Improve `setenv.sh` performance by replacing per-variable `get_section_value` shell subprocesses with a single Jinja2 template rendering pass via Python.

## Problem

The previous implementation called `get_section_value` (a Python subprocess invocation) individually for every variable in `.env` — roughly 60+ calls per setup run. Each call incurs Python startup overhead, making environment file generation slow.

## Solution

The `.env` file is now generated using a two-step approach:

1. A static `.env.template` file is written using a heredoc with `'EOF'` (no shell expansion), containing Jinja2-style `{{ section.key }}` placeholders.
2. A single `python3 config.py --resolve-template` call reads the `.env.template` and configuration yaml file, rendering the template in one pass, and writes the final `.env` file.

The template file is cleaned up immediately after rendering.

## Changes

- **`.setup/config/setenv.sh`**: Replaced all `$(get_section_value ...)` calls with `{{ section.key }}` Jinja2 placeholders in a quoted heredoc. Added a single `python3 config.py --resolve-template` call to render the template.
- **`.setup/lib/config.py`**: Added `resolve_template()` function and `--resolve-template <file>` CLI mode. Moved `load_config`/`render_config` calls before argument dispatch so the config is loaded once regardless of mode.

## Notes

- Also fixes a minor inconsistency: `DBB_LOG_FOLDER` was previously set twice (direct + `:-` fallback). The duplicate assignment is removed, keeping only the `:-` form.
- `SCAN_PYENV_ACTIVATE_PATH` was previously using `$PYENV_ACTIVATE_PATH` as its default variable name (likely a bug); corrected to `$SCAN_PYENV_ACTIVATE_PATH`.