### PR TITLE
Prevent early script exit while flushing stdout and stderr

### DIFF
--- a/.setup/setup/addcert.sh
+++ b/.setup/setup/addcert.sh
@@ -28,6 +28,7 @@ exec > >(while IFS= read -r line; do
     [[ -z "$line" ]] && continue
     printf "${CYAN}[ADD-CERTS]${NC} %s\n" "${line}" 2>/dev/null || true
 done) 2>&1
+trap 'exec >&- 2>&-; wait' EXIT
 
 finalize_results() {
     RC=$?

--- a/.setup/setup/clearcert.sh
+++ b/.setup/setup/clearcert.sh
@@ -19,6 +19,7 @@ exec > >(while IFS= read -r line; do
     [[ -z "$line" ]] && continue
     printf "${CYAN}[CLEARCERT]${NC} %s\n" "${line}" 2>/dev/null || true
 done) 2>&1
+trap 'exec >&- 2>&-; wait' EXIT
 
 ## CUSTOMIZE ##
 userid=${ZOS_ADMIN_USER}

--- a/.setup/setup/gencert-eku.sh
+++ b/.setup/setup/gencert-eku.sh
@@ -32,6 +32,7 @@ exec > >(while IFS= read -r line; do
     [[ -z "$line" ]] && continue
     printf "${CYAN}[GENCERT]${NC} %s\n" "${line}" 2>/dev/null || true
 done) 2>&1
+trap 'exec >&- 2>&-; wait' EXIT
 
 set -e  # Exit immediately on any non-zero return code
 

--- a/.setup/setup/grant-perm-user.sh
+++ b/.setup/setup/grant-perm-user.sh
@@ -25,6 +25,7 @@ exec > >(while IFS= read -r line; do
     [[ -z "$line" ]] && continue
     printf "${CYAN}[GRANT-USER]${NC} %s\n" "${line}" 2>/dev/null || true
 done) 2>&1
+trap 'exec >&- 2>&-; wait' EXIT
 
 # =========================
 # Parameter validation

--- a/.setup/setup/populate-db2-tables.sh
+++ b/.setup/setup/populate-db2-tables.sh
@@ -20,6 +20,7 @@ exec > >(while IFS= read -r line; do
     [[ -z "$line" ]] && continue
     printf "${CYAN}[POPULATE-DB2-TABLES]${NC} %s\n" "${line}" 2>/dev/null || true
 done) 2>&1
+trap 'exec >&- 2>&-; wait' EXIT
 
 # =========================
 # Environment

--- a/.setup/setup/populate-ims-tables.sh
+++ b/.setup/setup/populate-ims-tables.sh
@@ -20,6 +20,7 @@ exec > >(while IFS= read -r line; do
     [[ -z "$line" ]] && continue
     printf "${CYAN}[POPULATE-IMS-TABLES]${NC} %s\n" "${line}" 2>/dev/null || true
 done) 2>&1
+trap 'exec >&- 2>&-; wait' EXIT
 
 # =========================
 # Environment

--- a/.setup/setup/setup-cics-region.sh
+++ b/.setup/setup/setup-cics-region.sh
@@ -21,6 +21,7 @@ exec > >(while IFS= read -r line; do
     [[ -z "$line" ]] && continue
     printf "${CYAN}[ZCONFIG-CICS]${NC} %s\n" "${line}" 2>/dev/null || true
 done) 2>&1
+trap 'exec >&- 2>&-; wait' EXIT
 
 finalize_results() {
     RC=$?

--- a/.setup/setup/setup-db2-tables.sh
+++ b/.setup/setup/setup-db2-tables.sh
@@ -20,6 +20,7 @@ exec > >(while IFS= read -r line; do
     [[ -z "$line" ]] && continue
     printf "${CYAN}[SETUP-DB2-TABLES]${NC} %s\n" "${line}" 2>/dev/null || true
 done) 2>&1
+trap 'exec >&- 2>&-; wait' EXIT
 
 # =========================
 # Environment

--- a/.setup/setup/setup-debug.sh
+++ b/.setup/setup/setup-debug.sh
@@ -25,6 +25,7 @@ exec > >(while IFS= read -r line; do
     [[ -z "$line" ]] && continue
     printf "${CYAN}[DEBUG]${NC} %s\n" "${line}" 2>/dev/null || true
 done) 2>&1
+trap 'exec >&- 2>&-; wait' EXIT
 
 # =========================
 # Environment

--- a/.setup/setup/setup-frontend-server.sh
+++ b/.setup/setup/setup-frontend-server.sh
@@ -24,6 +24,7 @@ exec > >(while IFS= read -r line; do
     [[ -z "$line" ]] && continue
     printf "${CYAN}[FRONTEND]${NC} %s\n" "${line}" 2>/dev/null || true
 done) 2>&1
+trap 'exec >&- 2>&-; wait' EXIT
 
 # =========================
 # Environment

--- a/.setup/setup/setup-ims-bankz-regions.sh
+++ b/.setup/setup/setup-ims-bankz-regions.sh
@@ -20,6 +20,7 @@ exec > >(while IFS= read -r line; do
     [[ -z "$line" ]] && continue
     printf "${CYAN}[IMS-REGIONS]${NC} %s\n" "${line}" 2>/dev/null || true
 done) 2>&1
+trap 'exec >&- 2>&-; wait' EXIT
 
 # =========================
 # Environment

--- a/.setup/setup/setup-ims-region.sh
+++ b/.setup/setup/setup-ims-region.sh
@@ -21,6 +21,7 @@ exec > >(while IFS= read -r line; do
     [[ -z "$line" ]] && continue
     printf "${CYAN}[ZCONFIG-IMS]${NC} %s\n" "${line}" 2>/dev/null || true
 done) 2>&1
+trap 'exec >&- 2>&-; wait' EXIT
 
 # =========================
 # Environment

--- a/.setup/setup/setup-ims-tables.sh
+++ b/.setup/setup/setup-ims-tables.sh
@@ -26,6 +26,7 @@ exec > >(while IFS= read -r line; do
     [[ -z "$line" ]] && continue
     printf "${CYAN}[SETUP-IMS-TABLES]${NC} %s\n" "${line}" 2>/dev/null || true
 done) 2>&1
+trap 'exec >&- 2>&-; wait' EXIT
 
 # =========================
 # Delele IMS tables

--- a/.setup/setup/setup-zosconnect-server.sh
+++ b/.setup/setup/setup-zosconnect-server.sh
@@ -23,6 +23,7 @@ exec > >(while IFS= read -r line; do
     [[ -z "$line" ]] && continue
     printf "${CYAN}[ZOSCONNECT]${NC} %s\n" "${line}" 2>/dev/null || true
 done) 2>&1
+trap 'exec >&- 2>&-; wait' EXIT
 
 # =========================
 # Helper: verify a config file was written successfully

--- a/.setup/setup/validate-install.sh
+++ b/.setup/setup/validate-install.sh
@@ -24,6 +24,7 @@ exec > >(while IFS= read -r line; do
     [[ -z "$line" ]] && continue
     printf "${CYAN}[VALIDATE]${NC} %s\n" "${line}" 2>/dev/null || true
 done) 2>&1
+trap 'exec >&- 2>&-; wait' EXIT
 
 # =========================
 # Environment

--- a/.setup/tasks/task-dbb-build.sh
+++ b/.setup/tasks/task-dbb-build.sh
@@ -28,6 +28,7 @@ exec > >(while IFS= read -r line; do
     [[ -z "$line" ]] && continue
     printf "${CYAN}[DBB-BUILD]${NC} %s\n" "${line}"
 done) 2>&1
+trap 'exec >&- 2>&-; wait' EXIT
 
 # =========================
 # Environment

--- a/.setup/tasks/task-install-verification.sh
+++ b/.setup/tasks/task-install-verification.sh
@@ -22,6 +22,7 @@ exec > >(while IFS= read -r line; do
     [[ -z "$line" ]] && continue
     printf "${CYAN}[VERIFY]${NC} %s\n" "${line}"
 done) 2>&1
+trap 'exec >&- 2>&-; wait' EXIT
 
 # =========================
 # Environment

--- a/.setup/tasks/task-wazi-deploy.sh
+++ b/.setup/tasks/task-wazi-deploy.sh
@@ -26,6 +26,7 @@ exec > >(while IFS= read -r line; do
     [[ -z "$line" ]] && continue
     printf "${CYAN}[WAZIDEPLOY]${NC} %s\n" "${line}"
 done) 2>&1
+trap 'exec >&- 2>&-; wait' EXIT
 
 cd $SCRIPTS_DIR
 # =========================

--- a/.setup/tasks/task-zcodescan-static-scan.sh
+++ b/.setup/tasks/task-zcodescan-static-scan.sh
@@ -25,6 +25,7 @@ exec > >(while IFS= read -r line; do
     [[ -z "$line" ]] && continue
     printf "${CYAN}[ZCODESCAN]${NC} %s\n" "${line}"
 done) 2>&1
+trap 'exec >&- 2>&-; wait' EXIT
 
 
 # =========================


### PR DESCRIPTION
## Summary

Adds an `EXIT` trap (`trap 'exec >&- 2>&-; wait' EXIT`) across setup and task bash scripts to ensure all background process substitutions redirecting standard output and standard error finish flushing and cleanly exit before the main script process terminates.

## Problem

Scripts redirecting `stdout` and `stderr` via process substitution (e.g., `exec > >(while IFS= read -r line; do ... done) 2>&1`) can terminate before the subshell completes processing and writing log buffers. This can lead to truncated or dropped log outputs, race conditions on script completion, and intermittent early termination issues.

## Solution

Added `trap 'exec >&- 2>&-; wait' EXIT` after process substitution setup across:
- **Setup scripts** under `.setup/setup/`
- **Task scripts** under `.setup/tasks/`

Closing file descriptors (`exec >&- 2>&-`) sends EOF to the background logging loop, and `wait` ensures the subshell finishes draining before the parent process exits.

## Validation

- Verified that all modified scripts retain proper syntax and structure.
- Confirmed trap behavior correctly flushes outputs on normal script termination and exits cleanly.

## Testing

- Manual testing of a grub client install of Bank of Z
- Manual testing of a local USS based run of `setup-common.sh validate-prereqs`