### PR TITLE
bank-of-z server stop and start scripts

### DIFF
--- a/.setup/runtime-manage.sh
+++ b/.setup/runtime-manage.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+
+#########################################################
+# Runtime Management Script for Bank of Z
+# This script runs directly on z/OS USS (not remotely)
+#
+# Manages the lifecycle (stop / start / restart) of the
+# Bank of Z runtime servers WITHOUT touching any datasets
+# or application data.
+#
+# Used when the z/OS infrastructure is restarted and the
+# Bank of Z tasks need to be brought back up manually.
+#
+# Delegates to:
+#   .setup/setup/servers-stop.sh
+#   .setup/setup/servers-start.sh
+#
+# Usage:
+#   bash runtime-manage.sh <action> [scope]
+#
+# Actions:
+#   stop      Stop all servers (no data deletion)
+#   start     Start all servers
+#   restart   Stop then start all servers
+#
+# Scope (optional, default: --all):
+#   --all           IMS + CICS + z/OS Connect + Frontend
+#   --ims-only      IMS control tasks + IRLM + app regions only
+#   --cics-only     CICS region only
+#   --frontend-only z/OS Connect + Frontend Liberty only
+#
+# Examples:
+#   bash runtime-manage.sh stop
+#   bash runtime-manage.sh start --ims-only
+#   bash runtime-manage.sh restart
+#########################################################
+
+set -e
+
+# =========================
+# Source library scripts
+# =========================
+SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPTS_DIR/config/setenv.sh"
+
+#########################################################
+# Usage
+#########################################################
+print_usage() {
+    echo "Usage: bash runtime-manage.sh <action> [scope]"
+    echo ""
+    echo "Actions:"
+    echo "  stop      Stop all servers (no data deletion)"
+    echo "  start     Start all servers"
+    echo "  restart   Stop then start all servers"
+    echo ""
+    echo "Scope (optional, default: --all):"
+    echo "  --all           IMS + CICS + z/OS Connect + Frontend  (default)"
+    echo "  --ims-only      IMS control tasks + IRLM + app regions only"
+    echo "  --cics-only     CICS region only"
+    echo "  --frontend-only z/OS Connect + Frontend Liberty only"
+    echo ""
+    echo "Examples:"
+    echo "  bash runtime-manage.sh stop"
+    echo "  bash runtime-manage.sh start --ims-only"
+    echo "  bash runtime-manage.sh restart"
+    echo ""
+    echo "Environment variables:"
+    echo "  IMS_DISABLED   Set to true to skip all IMS tasks (default: false)"
+}
+
+#########################################################
+# Main
+#########################################################
+main() {
+    local action="${1:-}"
+    local scope_flag="${2:---all}"
+
+    # Validate scope
+    case "${scope_flag#--}" in
+        all|ims-only|cics-only|frontend-only) ;;
+        *)
+            print_error "Unknown scope: ${scope_flag}"
+            echo ""
+            print_usage
+            exit 1
+            ;;
+    esac
+
+    # Detect repo location (sets BANK_DIR, EXECUTION_MODE)
+    detect_bank_of_z_location
+
+    local stop_script="$BANK_DIR/.setup/setup/servers-stop.sh"
+    local start_script="$BANK_DIR/.setup/setup/servers-start.sh"
+
+    case "$action" in
+        stop)
+            print_stage "ACTION: Stop Bank of Z servers (scope: ${scope_flag#--})"
+            if [ ! -f "$stop_script" ]; then
+                print_error "Stop script not found: $stop_script"
+                exit 1
+            fi
+            print_info "Executing: bash $stop_script $scope_flag"
+            bash "$stop_script" "$scope_flag"
+            print_stage "STOP COMPLETE"
+            print_success "All requested servers have been stopped."
+            ;;
+        start)
+            print_stage "ACTION: Start Bank of Z servers (scope: ${scope_flag#--})"
+            if [ ! -f "$start_script" ]; then
+                print_error "Start script not found: $start_script"
+                exit 1
+            fi
+            print_info "Executing: bash $start_script $scope_flag"
+            bash "$start_script" "$scope_flag"
+            print_stage "START COMPLETE"
+            print_success "All requested servers have been started."
+            ;;
+        restart)
+            print_stage "ACTION: Restart Bank of Z servers (scope: ${scope_flag#--})"
+            if [ ! -f "$stop_script" ]; then
+                print_error "Stop script not found: $stop_script"
+                exit 1
+            fi
+            if [ ! -f "$start_script" ]; then
+                print_error "Start script not found: $start_script"
+                exit 1
+            fi
+            print_info "Executing: bash $stop_script $scope_flag"
+            bash "$stop_script" "$scope_flag"
+            print_info "Executing: bash $start_script $scope_flag"
+            bash "$start_script" "$scope_flag"
+            print_stage "RESTART COMPLETE"
+            print_success "All requested servers have been restarted."
+            ;;
+        -h|--help|help|"")
+            print_usage
+            ;;
+        *)
+            print_error "Unknown action: $action"
+            echo ""
+            print_usage
+            exit 1
+            ;;
+    esac
+}
+
+# Run main function
+main "$@"
+exit $?
+
+# Made with Bob

--- a/.setup/setup-common.sh
+++ b/.setup/setup-common.sh
@@ -25,54 +25,25 @@ source "$SCRIPTS_DIR/config/setenv.sh"
 stage_stop_tasks() {
     set +e
     print_stage "STAGE: Stop Bank of Z running tasks (if any)"
+
     # =========================
-    # Stop IBM IMS regions
+    # Stop all running servers
+    # (delegated to servers-stop.sh — no data deletion)
     # =========================
-    # Delete stale stop members so jsub fails silently rather than executing
-    # outdated JCL that may reference deleted datasets.
-    mrm "${IMS_APP_HLQ}.JOBS(STOPMPP1)" 2>/dev/null || true
-    mrm "${IMS_APP_HLQ}.JOBS(STOPMPP2)" 2>/dev/null || true
-    mrm "${IMS_APP_HLQ}.IMSJAVA.JOBS(STOPJMP)" 2>/dev/null || true
-    jsub "${IMS_APP_HLQ}.JOBS(STOPMPP1)"  2>/dev/null
-    jsub "${IMS_APP_HLQ}.JOBS(STOPMPP2)"  2>/dev/null
-    jsub "${IMS_APP_HLQ}.IMSJAVA.JOBS(STOPJMP)"  2>/dev/null
-    sleep 5
-    jcan P "${IMS_DATASTORE}JMP1" 2>/dev/null
-    jcan P "${IMS_DATASTORE}MPP1" 2>/dev/null
-    jcan P "${IMS_DATASTORE}MPP2" 2>/dev/null
-    sleep 5
-    opercmd "C ${IMS_DATASTORE}DRC" 2>/dev/null
-    sleep 1
-    opercmd "C ${IMS_DATASTORE}OM" 2>/dev/null
-    sleep 1
-    opercmd "C ${IMS_DATASTORE}RM" 2>/dev/null
-    sleep 1
-    opercmd "C ${IMS_DATASTORE}SCI" 2>/dev/null
-    sleep 1
-    # IMS Connect
-    opercmd "C ${IMS_DATASTORE}HWS" 2>/dev/null
-    sleep 1
-    opercmd "C ${IMS_DATASTORE}ODB" 2>/dev/null
-    sleep 1
-    opercmd "C ${IMS_DATABASE_LOCK_MANAGER_SERVER_NAME}" 2>/dev/null
-    
+    if [ ! -f "$BANK_DIR/.setup/setup/servers-stop.sh" ]; then
+        print_error "Stop script not found: $BANK_DIR/.setup/setup/servers-stop.sh"
+        exit 1
+    fi
+    print_info "Running servers stop script..."
+    print_info "Executing: bash $BANK_DIR/.setup/setup/servers-stop.sh --all"
+    cd "$BANK_DIR"
+    bash .setup/setup/servers-stop.sh --all
+
     # =========================
-    # Stop IBM CICS regions
+    # Stop IMS1 (legacy / spare)
     # =========================
-    jcan P "CICS${APP_SHORT_NAME}"  2>/dev/null
-    opercmd "C CICS${APP_SHORT_NAME}"  2>/dev/null
-    
-    # =========================
-    # Stop IBM zconn servers
-    # =========================
-    jcan P "BAQ${APP_SHORT_NAME}"  2>/dev/null
-    jcan P "FE${APP_SHORT_NAME}"  2>/dev/null
-    
-    # =========================
-    # Stop IMS1
-    # =========================
-    jcan P "IMS1*" 2>/dev/null
-    
+    jcan P "IMS1*" 2>/dev/null || true
+
     # ===========================
     # Clean application datasets
     # ===========================

--- a/.setup/setup/servers-start.sh
+++ b/.setup/setup/servers-start.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+
+#########################################################
+# servers-start.sh — Start Bank of Z runtime servers
+#
+# Starts the Bank of Z runtime servers. Intended for use
+# after an infrastructure restart when tasks need to be
+# brought back up without re-provisioning.
+#
+# Usage:
+#   bash servers-start.sh [scope]
+#
+# Scope (optional, default: --all):
+#   --all           IMS + CICS + Frontend  (start order)
+#   --ims-only      IMS control tasks + IRLM + application regions
+#   --cics-only     CICS region only
+#   --frontend-only z/OS Connect + Frontend Liberty only
+#
+# Examples:
+#   bash servers-start.sh
+#   bash servers-start.sh --ims-only
+#   bash servers-start.sh --frontend-only
+#
+# Environment variables:
+#   IMS_DISABLED    Set to true to skip all IMS tasks (default: false)
+#########################################################
+
+set -e
+
+# =========================
+# Source library scripts
+# =========================
+SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPTS_DIR/../config/setenv.sh"
+
+# =========================
+# Environment
+# =========================
+export PATH="${ZOAU_HOME:-}/bin:$PATH"
+export LIBPATH="${ZOAU_HOME:-}/lib:${LIBPATH:-}"
+
+#########################################################
+# Start IMS control tasks + IRLM (warm restart)
+#########################################################
+start_ims_control() {
+    print_stage "STAGE: Start IMS control tasks + IRLM (warm restart)"
+    set +e
+
+    # IRLM must be started before CTL
+    print_info "Starting ${IMS_DATABASE_LOCK_MANAGER_SERVER_NAME} (IRLM)..."
+    opercmd "S ${IMS_DATABASE_LOCK_MANAGER_SERVER_NAME}" 2>/dev/null || true
+    sleep 2
+
+    # Start IMS common services in order: SCI → OM → RM
+    print_info "Starting ${IMS_DATASTORE}SCI..."
+    opercmd "S ${IMS_DATASTORE}SCI" 2>/dev/null || true
+    sleep 2
+
+    print_info "Starting ${IMS_DATASTORE}OM..."
+    opercmd "S ${IMS_DATASTORE}OM" 2>/dev/null || true
+    sleep 2
+
+    print_info "Starting ${IMS_DATASTORE}RM..."
+    opercmd "S ${IMS_DATASTORE}RM" 2>/dev/null || true
+    sleep 2
+
+    # Start IMS CTL — implicitly starts IMS2DLI and IMS2DRC
+    print_info "Submitting ${IMS_APP_HLQ}.PROCLIB(${IMS_DATASTORE}CTL) via jsub..."
+    jsub "${IMS_APP_HLQ}.PROCLIB(${IMS_DATASTORE}CTL)" 2>/dev/null || true
+
+    # Allow CTL and its dependent regions time to initialise
+    print_info "Waiting for IMS CTL and dependent regions to initialise (30s)..."
+    sleep 30
+
+    # Post-start: Open Database (ODB) then IMS Connect (HWS)
+    print_info "Starting ${IMS_DATASTORE}ODB..."
+    opercmd "S ${IMS_DATASTORE}ODB" 2>/dev/null || true
+    sleep 2
+
+    print_info "Starting ${IMS_DATASTORE}HWS..."
+    opercmd "S ${IMS_DATASTORE}HWS" 2>/dev/null || true
+    sleep 2
+
+    print_success "IMS control tasks and IRLM started"
+    set -e
+}
+
+#########################################################
+# Start IMS application regions (MPP / JMP)
+#########################################################
+start_ims_regions() {
+    print_stage "STAGE: Start IMS application regions (MPP / JMP)"
+    set +e
+
+    print_info "Submitting ${IMS_DATASTORE}MPP2..."
+    jsub "${IMS_APP_HLQ}.JOBS(${IMS_DATASTORE}MPP2)" 2>/dev/null || true
+    sleep 5
+
+    print_info "Submitting ${IMS_DATASTORE}MPP1..."
+    jsub "${IMS_APP_HLQ}.JOBS(${IMS_DATASTORE}MPP1)" 2>/dev/null || true
+    sleep 5
+
+    print_info "Submitting STARTJMP (JMP region)..."
+    jsub "${IMS_APP_HLQ}.IMSJAVA.JOBS(STARTJMP)" 2>/dev/null || true
+    sleep 5
+
+    print_success "IMS application regions started"
+    set -e
+}
+
+#########################################################
+# Start CICS region
+#########################################################
+start_cics() {
+    print_stage "STAGE: Start CICS region"
+    set +e
+
+    if [[ "$CICS_SYS_PROCLIB" != "${APP_HLQ}.PROCLIB" ]]; then
+        print_info "Starting CICS${APP_SHORT_NAME} via opercmd (system PROCLIB)..."
+        opercmd "S CICS${APP_SHORT_NAME}" 2>/dev/null || true
+    else
+        print_info "Starting CICS${APP_SHORT_NAME} via jsub (application PROCLIB)..."
+        jsub "${APP_HLQ}.PROCLIB(CICS${APP_SHORT_NAME}J)" 2>/dev/null || true
+    fi
+    sleep 3
+
+    print_success "CICS region start command issued"
+    set -e
+}
+
+#########################################################
+# Start z/OS Connect and Frontend Liberty servers
+#########################################################
+start_frontend() {
+    print_stage "STAGE: Start z/OS Connect and Frontend Liberty servers"
+    set +e
+
+    if [[ "$ZOSCONNECT_SYS_PROCLIB" != "${APP_HLQ}.PROCLIB" ]]; then
+        print_info "Starting BAQ${APP_SHORT_NAME} (z/OS Connect) via opercmd..."
+        opercmd "S BAQ${APP_SHORT_NAME}" 2>/dev/null || true
+    else
+        print_info "Starting BAQ${APP_SHORT_NAME} (z/OS Connect) via jsub..."
+        jsub "${ZOSCONNECT_SYS_PROCLIB}(BAQ${APP_SHORT_NAME}J)" 2>/dev/null || true
+    fi
+
+    if [[ "$FRONTEND_SYS_PROCLIB" != "${APP_HLQ}.PROCLIB" ]]; then
+        print_info "Starting FE${APP_SHORT_NAME} (Frontend Liberty) via opercmd..."
+        opercmd "S FE${APP_SHORT_NAME}" 2>/dev/null || true
+    else
+        print_info "Starting FE${APP_SHORT_NAME} (Frontend Liberty) via jsub..."
+        jsub "${FRONTEND_SYS_PROCLIB}(FE${APP_SHORT_NAME}J)" 2>/dev/null || true
+    fi
+    sleep 3
+
+    print_success "z/OS Connect and Frontend Liberty servers start commands issued"
+    set -e
+}
+
+#########################################################
+# Main
+#########################################################
+main() {
+    local scope_flag="${1:---all}"
+    local scope="${scope_flag#--}"   # strip leading --
+
+    case "$scope" in
+        all)
+            # Start order: IMS → CICS → Frontend
+            if [[ "${IMS_DISABLED:-false}" != "true" ]]; then
+                start_ims_control
+                start_ims_regions
+            else
+                print_info "IMS_DISABLED=true — skipping IMS start"
+            fi
+            start_cics
+            start_frontend
+            ;;
+        ims-only)
+            start_ims_control
+            start_ims_regions
+            ;;
+        cics-only)
+            start_cics
+            ;;
+        frontend-only)
+            start_frontend
+            ;;
+        *)
+            print_error "Unknown scope: ${scope_flag}"
+            echo "Usage: bash servers-start.sh [--all|--ims-only|--cics-only|--frontend-only]"
+            exit 1
+            ;;
+    esac
+
+    print_success "servers-start.sh complete (scope: ${scope})"
+}
+
+main "$@"
+exit $?
+
+# Made with Bob

--- a/.setup/setup/servers-stop.sh
+++ b/.setup/setup/servers-stop.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+
+#########################################################
+# servers-stop.sh — Stop Bank of Z runtime servers
+#
+# Stops the Bank of Z runtime servers WITHOUT touching
+# any datasets or application data.
+#
+# Usage:
+#   bash servers-stop.sh [scope]
+#
+# Scope (optional, default: --all):
+#   --all           Frontend + CICS + IMS  (stop order)
+#   --ims-only      IMS application regions + control tasks + IRLM
+#   --cics-only     CICS region only
+#   --frontend-only z/OS Connect + Frontend Liberty only
+#
+# Examples:
+#   bash servers-stop.sh
+#   bash servers-stop.sh --ims-only
+#   bash servers-stop.sh --frontend-only
+#
+# Environment variables:
+#   IMS_DISABLED    Set to true to skip all IMS tasks (default: false)
+#########################################################
+
+set -e
+
+# =========================
+# Source library scripts
+# =========================
+SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPTS_DIR/../config/setenv.sh"
+
+# =========================
+# Environment
+# =========================
+export PATH="${ZOAU_HOME:-}/bin:$PATH"
+export LIBPATH="${ZOAU_HOME:-}/lib:${LIBPATH:-}"
+
+#########################################################
+# Stop z/OS Connect and Frontend Liberty servers
+#########################################################
+stop_frontend() {
+    print_stage "STAGE: Stop z/OS Connect and Frontend Liberty servers"
+    set +e
+
+    print_info "Cancelling BAQ${APP_SHORT_NAME} (z/OS Connect)..."
+    jcan P "BAQ${APP_SHORT_NAME}" 2>/dev/null || true
+    opercmd "C BAQ${APP_SHORT_NAME}" 2>/dev/null || true
+
+    print_info "Cancelling FE${APP_SHORT_NAME} (Frontend Liberty)..."
+    jcan P "FE${APP_SHORT_NAME}" 2>/dev/null || true
+    opercmd "C FE${APP_SHORT_NAME}" 2>/dev/null || true
+    sleep 2
+
+    print_success "z/OS Connect and Frontend Liberty servers stopped"
+    set -e
+}
+
+#########################################################
+# Stop CICS region
+#########################################################
+stop_cics() {
+    print_stage "STAGE: Stop CICS region"
+    set +e
+
+    print_info "Cancelling CICS${APP_SHORT_NAME} job (if submitted)..."
+    jcan P "CICS${APP_SHORT_NAME}" 2>/dev/null || true
+
+    print_info "Issuing C CICS${APP_SHORT_NAME}..."
+    opercmd "C CICS${APP_SHORT_NAME}" 2>/dev/null || true
+    sleep 2
+
+    print_success "CICS region stopped"
+    set -e
+}
+
+#########################################################
+# Stop IMS application regions (MPP / JMP)
+#########################################################
+stop_ims_regions() {
+    print_stage "STAGE: Stop IMS application regions (MPP / JMP)"
+    set +e
+
+    # Delete stale stop members so jsub fails silently rather than executing
+    # outdated JCL that may reference deleted datasets.
+    print_info "Removing stale STOPMPP1 / STOPMPP2 / STOPJMP members..."
+    mrm "${IMS_APP_HLQ}.JOBS(STOPMPP1)"         2>/dev/null || true
+    mrm "${IMS_APP_HLQ}.JOBS(STOPMPP2)"         2>/dev/null || true
+    mrm "${IMS_APP_HLQ}.IMSJAVA.JOBS(STOPJMP)"  2>/dev/null || true
+
+    print_info "Submitting STOPMPP1 / STOPMPP2 / STOPJMP JCL..."
+    jsub "${IMS_APP_HLQ}.JOBS(STOPMPP1)"         2>/dev/null || true
+    jsub "${IMS_APP_HLQ}.JOBS(STOPMPP2)"         2>/dev/null || true
+    jsub "${IMS_APP_HLQ}.IMSJAVA.JOBS(STOPJMP)"  2>/dev/null || true
+    sleep 5
+
+    print_info "Cancelling ${IMS_DATASTORE}JMP1 / MPP1 / MPP2 (if still active)..."
+    jcan P "${IMS_DATASTORE}JMP1" 2>/dev/null || true
+    jcan P "${IMS_DATASTORE}MPP1" 2>/dev/null || true
+    jcan P "${IMS_DATASTORE}MPP2" 2>/dev/null || true
+    sleep 5
+
+    print_success "IMS application regions stopped"
+    set -e
+}
+
+#########################################################
+# Stop IMS control tasks + IRLM
+#########################################################
+stop_ims_control() {
+    print_stage "STAGE: Stop IMS control tasks + IRLM"
+    set +e
+
+    # Stop IMS Connect (HWS) and Open Database (ODB) first
+    print_info "Stopping ${IMS_DATASTORE}HWS..."
+    opercmd "C ${IMS_DATASTORE}HWS" 2>/dev/null || true
+    sleep 1
+
+    print_info "Stopping ${IMS_DATASTORE}ODB..."
+    opercmd "C ${IMS_DATASTORE}ODB" 2>/dev/null || true
+    sleep 1
+
+    # Stop IMS DRC (dependent region controller)
+    print_info "Stopping ${IMS_DATASTORE}DRC..."
+    opercmd "C ${IMS_DATASTORE}DRC" 2>/dev/null || true
+    sleep 1
+
+    # Stop IMS CTL (also terminates DLI)
+    print_info "Stopping ${IMS_DATASTORE}CTL..."
+    opercmd "C ${IMS_DATASTORE}CTL" 2>/dev/null || true
+    sleep 2
+
+    # Stop IMS common services
+    print_info "Stopping ${IMS_DATASTORE}OM..."
+    opercmd "C ${IMS_DATASTORE}OM" 2>/dev/null || true
+    sleep 1
+
+    print_info "Stopping ${IMS_DATASTORE}RM..."
+    opercmd "C ${IMS_DATASTORE}RM" 2>/dev/null || true
+    sleep 1
+
+    print_info "Stopping ${IMS_DATASTORE}SCI..."
+    opercmd "C ${IMS_DATASTORE}SCI" 2>/dev/null || true
+    sleep 1
+
+    # IRLM must be stopped last (after all IMS address spaces)
+    print_info "Stopping ${IMS_DATABASE_LOCK_MANAGER_SERVER_NAME} (IRLM)..."
+    opercmd "C ${IMS_DATABASE_LOCK_MANAGER_SERVER_NAME}" 2>/dev/null || true
+    sleep 2
+
+    print_success "IMS control tasks and IRLM stopped"
+    set -e
+}
+
+#########################################################
+# Main
+#########################################################
+main() {
+    local scope_flag="${1:---all}"
+    local scope="${scope_flag#--}"   # strip leading --
+
+    case "$scope" in
+        all)
+            # Stop order: Frontend → CICS → IMS
+            stop_frontend
+            stop_cics
+            if [[ "${IMS_DISABLED:-false}" != "true" ]]; then
+                stop_ims_regions
+                stop_ims_control
+            else
+                print_info "IMS_DISABLED=true — skipping IMS stop"
+            fi
+            ;;
+        ims-only)
+            stop_ims_regions
+            stop_ims_control
+            ;;
+        cics-only)
+            stop_cics
+            ;;
+        frontend-only)
+            stop_frontend
+            ;;
+        *)
+            print_error "Unknown scope: ${scope_flag}"
+            echo "Usage: bash servers-stop.sh [--all|--ims-only|--cics-only|--frontend-only]"
+            exit 1
+            ;;
+    esac
+
+    print_success "servers-stop.sh complete (scope: ${scope})"
+}
+
+main "$@"
+exit $?
+
+# Made with Bob


### PR DESCRIPTION
# Summary

Refactors server lifecycle management for the Bank of Z application by extracting stop/start logic into dedicated, reusable scripts. Previously, server stop commands were inlined directly in `setup-common.sh`. This PR introduces `servers-stop.sh` and `servers-start.sh` as standalone scripts with scoped execution support (`--all`, `--ims-only`, `--cics-only`, `--frontend-only`), and adds a top-level `runtime-manage.sh` orchestrator for managing the full server lifecycle (stop, start, restart) independently of provisioning or data operations.

# Files Changed

📄 `.setup/runtime-manage.sh`

New top-level orchestration script for managing the Bank of Z server lifecycle on z/OS USS. Accepts an `action` (`stop`, `start`, `restart`) and an optional `scope` flag, then delegates to `servers-stop.sh` and/or `servers-start.sh` accordingly. Includes usage documentation, input validation, and clear stage/success messaging. Intended for use when the z/OS infrastructure is restarted and servers need to be brought back up manually without touching any datasets or application data.

📄 `.setup/setup-common.sh`

Refactored the `stage_stop_tasks` function to remove all inlined server stop commands (IMS regions, CICS, z/OS Connect). These are now delegated to the new `servers-stop.sh --all` script. The only remaining inline command is the legacy `jcan P "IMS1*"` call, which has been updated to use `|| true` for safer error handling. Also adds a guard to exit early with an error if `servers-stop.sh` is not found.

📄 `.setup/setup/servers-start.sh`

New script responsible for starting Bank of Z runtime servers. Implements four scoped start functions — `start_ims_control`, `start_ims_regions`, `start_cics`, and `start_frontend` — each handling the appropriate `opercmd`/`jsub` calls with correct startup ordering and delays. Supports the `IMS_DISABLED` environment variable to skip IMS tasks entirely. Start order when using `--all` is IMS → CICS → Frontend.

📄 `.setup/setup/servers-stop.sh`

New script responsible for stopping Bank of Z runtime servers without modifying any datasets or application data. Implements four scoped stop functions — `stop_frontend`, `stop_cics`, `stop_ims_regions`, and `stop_ims_control` — with proper teardown ordering and safe error handling via `|| true`. Stale JCL stop members are removed before resubmission to prevent outdated JCL from executing. Stop order when using `--all` is Frontend → CICS → IMS. Supports the `IMS_DISABLED` environment variable to skip IMS tasks.